### PR TITLE
Removing support for parameters in queries

### DIFF
--- a/salesforcecdpconnector/connection.py
+++ b/salesforcecdpconnector/connection.py
@@ -14,7 +14,7 @@ from .metadata_processor import MetadataProcessor
 
 apilevel = "2.0"
 threadsafety = 2
-paramstyle = "qmark"
+paramstyle = None
 
 
 class SalesforceCDPConnection:

--- a/salesforcecdpconnector/cursor.py
+++ b/salesforcecdpconnector/cursor.py
@@ -16,11 +16,6 @@ class SalesforceCDPCursor:
     This class represents the cursor
     """
 
-    _TRANSLATION_TABLE = str.maketrans({"\\": r"\\",
-                                        "\n": r"\\n",
-                                        "\r": r"\\r",
-                                        "'": r"\'"})
-
     def __init__(self, connection):
         self.arraysize = 1
         self.description = None
@@ -154,25 +149,8 @@ class SalesforceCDPCursor:
             raise Error('Attempting operation while connection is closed')
 
     def _resolve_query_with_params(self, query, params):
-        params_count_from_query = query.count('?')
-        if params is None and params_count_from_query == 0:
-            return query
-
         if params:
             raise Exception('Parameters are not supported')
-
-        return query
-
-    def _replace_next_param(self, query, param):
-        if param is None:
-            query = query.replace('?', 'null', 1)
-        elif self._is_numeric(param):
-            query = query.replace('?', str(param), 1)
-        else:
-            if not isinstance(param, str):
-                param = str(param)
-            param = param.translate(self._TRANSLATION_TABLE)
-            query = query.replace('?', f"'{str(param)}'", 1)
         return query
 
     def _is_iterable(self, param):

--- a/salesforcecdpconnector/cursor.py
+++ b/salesforcecdpconnector/cursor.py
@@ -158,13 +158,8 @@ class SalesforceCDPCursor:
         if params is None and params_count_from_query == 0:
             return query
 
-        if self._is_iterable(params) and params_count_from_query == len(params):
-            for param in params:
-                query = self._replace_next_param(query, param)
-        elif params_count_from_query == 1 and params is not None:
-            query = self._replace_next_param(query, params)
-        else:
-            raise Exception('Parameter count not matching')
+        if params:
+            raise Exception('Parameters are not supported')
 
         return query
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = salesforce-cdp-connector
-version = 1.0.13
+version = 1.0.14
 author = Query Service
 description = Python Connector for Salesforce CDP
 long_description = file: README.md

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -155,5 +155,12 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(len(all_records), 3)
         cursor.close()
 
+    def test_params_fail(self):
+        connection = SalesforceCDPConnection('login_url', 'username', 'password', 'client_id', 'client_secret')
+        cursor = connection.cursor()
+        with self.assertRaises(Exception) as context:
+            cursor.execute("select * from UnifiedIndividuals__dlm where col__c = ?", ['test'])
+        self.assertTrue("Parameters are not supported" in context.exception.args)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The present implementation for supporting params within the connector exhibits several limitations. It lacks proper escaping functionality and merely performs basic substitution by searching and replacing the '?' placeholders in the query. Consequently, in order to prevent reliance on this feature by clients, support for PreparedStatements is being phased out.