### PR TITLE
fixes the publish ci being broken by not using a string for version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
-          python-version: 3.10
+          python-version: "3.10"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
     - name: Install dependencies


### PR DESCRIPTION
GitHub Actions was correctly interpreting this python version as 3.1 not 3.10, making it a string should fix that.