### PR TITLE
add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What
+Describe the changes you've made in this PR. What functionality was added, modified, or removed?
+
+## Why
+Explain the motivation behind these changes. What problem does this solve?
+
+## How
+Summarize implementation approach and technical decisions made.
+
+## Additional Notes
+Any additional information that reviewers should know (feel free to delete this section if not applicable).


### PR DESCRIPTION
## What
This pull request adds a template to standardize the description of a PR to meet our expectations.

## Why
This should speed up contributions to the project by informing folks of our expectations on a PR ahead of time.

## How
Added a file at `.github/pull_request_template.md` per the [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template)