### PR TITLE
Add Cursor.get_query_status() accessor

### DIFF
--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -52,6 +52,9 @@ from .types import BINARY, DATETIME, NUMBER, ROWID, STRING
 # Import and expose metadata structures
 from .metadata import DataCloudTable, Field
 
+# Import and expose query status structure (used by Cursor.get_query_status)
+from .api.models import QueryStatus
+
 # Import connection
 from .connection import Connection
 
@@ -206,6 +209,8 @@ __all__ = [
     # Metadata structures
     "DataCloudTable",
     "Field",
+    # Query status structure
+    "QueryStatus",
     # Authenticators (advanced usage)
     "UsernamePasswordAuthenticator",
     "JWTAuthenticator",

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
@@ -13,14 +13,21 @@ class QueryStatus:
     """
     Status information for a query.
 
+    Mirrors the `QuerySqlStatusRepresentation` payload Connect API V3 returns
+    on `GET /services/data/v*/ssot/query-sql/{queryId}`. Fields beyond these
+    are not currently emitted by the server.
+
     Attributes:
-        query_id: Unique identifier for the query
-        completion_status: Status of query execution (Running, ResultsProduced, Finished, etc.)
-        progress: Progress percentage (0.0 to 1.0)
-        row_count: Total number of rows in the result set
-        chunk_count: Number of chunks the results are divided into
-        expiration_time: When the query results expire (if applicable)
+        query_id: Unique identifier for the query.
+        completion_status: ``Running`` / ``ResultsProduced`` / ``Finished`` /
+            ``Unspecified`` (case may vary; ``is_complete()`` normalizes).
+        progress: Server-side progress estimate, 0.0 to 1.0.
+        row_count: Total rows in the result set.
+        chunk_count: Number of chunks the result is divided into.
+        expiration_time: When the result expires from the server (string;
+            often a protobuf-text representation of a timestamp).
     """
+
     query_id: str
     completion_status: str
     progress: float
@@ -30,15 +37,7 @@ class QueryStatus:
 
     @classmethod
     def from_dict(cls, data: dict) -> "QueryStatus":
-        """
-        Create QueryStatus from API response dictionary.
-
-        Args:
-            data: Status dictionary from API response
-
-        Returns:
-            QueryStatus instance
-        """
+        """Create QueryStatus from a Connect API status payload dictionary."""
         return cls(
             query_id=data.get("queryId", ""),
             completion_status=data.get("completionStatus", ""),
@@ -52,23 +51,15 @@ class QueryStatus:
         """
         Check if the query has completed execution.
 
-        The completion status is case-insensitive and may use different formats:
-        - "ResultsProduced" or "RESULTSPRODUCED" or "RESULTS_PRODUCED"
-        - "Finished" or "FINISHED"
-
-        Returns:
-            True if query is complete, False otherwise
+        The completion status is case-insensitive and may use different
+        formats: ``ResultsProduced`` / ``RESULTSPRODUCED`` /
+        ``RESULTS_PRODUCED`` / ``Finished`` / ``FINISHED``.
         """
         status_upper = self.completion_status.upper().replace("_", "")
         return status_upper in ("RESULTSPRODUCED", "FINISHED")
 
     def is_running(self) -> bool:
-        """
-        Check if the query is still running.
-
-        Returns:
-            True if query is running, False otherwise
-        """
+        """Check if the query is still running."""
         return not self.is_complete()
 
 

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
@@ -7,7 +7,7 @@ The Cursor class executes queries and manages result retrieval.
 from typing import Any, Dict, List, Optional, Tuple
 
 from .api.client import DataCloudQueryClient
-from .api.models import ColumnMetadata
+from .api.models import ColumnMetadata, QueryStatus
 from .exceptions import InterfaceError, NotSupportedError
 from .types import build_description_tuple, convert_datacloud_value
 
@@ -40,6 +40,10 @@ class Cursor:
         self._description: Optional[List[Tuple]] = None
         self._rowcount: int = -1  # DB-API 2.0: -1 for SELECT, else number of rows affected
         self._closed: bool = False
+        # Latest QueryStatus observed on this cursor — refreshed by execute()
+        # and by the polling loop. Returned by get_query_status() without an
+        # extra HTTP call.
+        self._query_status: Optional[QueryStatus] = None
 
     @property
     def description(self) -> Optional[List[Tuple]]:
@@ -173,6 +177,7 @@ class Cursor:
         self._query_id = response.status.query_id
         self._metadata = response.metadata
         self._total_row_count = response.status.row_count
+        self._query_status = response.status
         self._rowcount = -1  # SELECT queries return -1
         self._build_description()
 
@@ -186,6 +191,7 @@ class Cursor:
             # Asynchronous response - need to poll until complete
             final_status = self._client.poll_until_complete(self._query_id)
             self._total_row_count = final_status.row_count
+            self._query_status = final_status
 
             # Fetch first chunk
             self._fetch_next_chunk()
@@ -322,6 +328,29 @@ class Cursor:
         self._check_query_executed()
 
         self._client.cancel_query(self._query_id)
+
+    def get_query_status(self) -> Optional[QueryStatus]:
+        """
+        Return the most recently observed QueryStatus for this cursor's query.
+
+        Non-blocking — does not issue an extra HTTP call. The status is
+        refreshed when `execute()` runs and after the async polling loop
+        completes. Exposes the fields the Connect API V3 status response
+        carries today: ``query_id``, ``completion_status``, ``progress``,
+        ``row_count``, ``chunk_count``, ``expiration_time``.
+
+        Returns:
+            The latest QueryStatus, or None if no query has been executed.
+
+        Example:
+            cursor.execute("SELECT ...")
+            for _ in cursor:
+                pass
+            status = cursor.get_query_status()
+            print(status.row_count, status.progress)
+        """
+        self._check_closed()
+        return self._query_status
 
     def fetch_df(self):
         """

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -6,6 +6,7 @@ import pytest
 import responses
 
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
+from salesforce_datacloud_connector.api.models import QueryStatus
 from salesforce_datacloud_connector.exceptions import ProgrammingError
 
 
@@ -367,3 +368,49 @@ def test_auth_token_included():
     )
 
     client.execute_query("SELECT 1")
+
+
+def test_query_status_from_dict_real_payload():
+    """Verbatim shape Connect API V3 returns on `GET /ssot/query-sql/{id}`."""
+    status = QueryStatus.from_dict(
+        {
+            "queryId": "q1",
+            "completionStatus": "Finished",
+            "progress": 1.0,
+            "rowCount": 1288,
+            "chunkCount": 1,
+            "expirationTime": "seconds: 1738344542\n",
+        }
+    )
+
+    assert status.query_id == "q1"
+    assert status.is_complete()
+    assert status.row_count == 1288
+    assert status.chunk_count == 1
+    assert status.progress == 1.0
+    assert status.expiration_time == "seconds: 1738344542\n"
+
+
+def test_query_status_from_empty_dict_does_not_throw():
+    status = QueryStatus.from_dict({})
+    assert status.query_id == ""
+    assert status.completion_status == ""
+    assert status.progress == 0.0
+    assert status.row_count == 0
+    assert status.chunk_count == 0
+    assert status.expiration_time is None
+
+
+def test_query_status_unknown_keys_ignored():
+    """Forward-compat: extra fields the server may add later must not raise."""
+    status = QueryStatus.from_dict(
+        {
+            "queryId": "q1",
+            "completionStatus": "Finished",
+            "progress": 1.0,
+            "rowCount": 0,
+            "chunkCount": 0,
+            "newServerSideField": {"foo": "bar"},
+        }
+    )
+    assert status.is_complete()

--- a/salesforce_datacloud_connector/tests/test_cursor.py
+++ b/salesforce_datacloud_connector/tests/test_cursor.py
@@ -7,7 +7,11 @@ from unittest.mock import Mock
 import pytest
 
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
-from salesforce_datacloud_connector.api.models import ColumnMetadata, QueryResponse, QueryStatus
+from salesforce_datacloud_connector.api.models import (
+    ColumnMetadata,
+    QueryResponse,
+    QueryStatus,
+)
 from salesforce_datacloud_connector.cursor import Cursor
 from salesforce_datacloud_connector.exceptions import InterfaceError, NotSupportedError
 
@@ -394,3 +398,99 @@ def test_fetch_before_execute():
 
     with pytest.raises(InterfaceError):
         cursor.fetchmany(10)
+
+
+def test_get_query_status_before_execute():
+    """get_query_status() returns None before any query has run."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    assert cursor.get_query_status() is None
+
+
+def test_get_query_status_after_sync_execute():
+    """For a synchronous query, returns the status from the initial response."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    status = QueryStatus(
+        query_id="q1",
+        completion_status="ResultsProduced",
+        progress=1.0,
+        row_count=2,
+        chunk_count=1,
+    )
+    client.execute_query.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=2,
+        status=status,
+    )
+
+    cursor.execute("SELECT name FROM users")
+
+    observed = cursor.get_query_status()
+    assert observed is status
+    # Non-blocking: get_query_status() must NOT issue a status HTTP call.
+    client.get_query_status.assert_not_called()
+
+
+def test_get_query_status_after_async_poll():
+    """For an async query, returns the final polled status, not the initial Running one."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="Running",
+            progress=0.1,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    final = QueryStatus(
+        query_id="q1",
+        completion_status="Finished",
+        progress=1.0,
+        row_count=2,
+        chunk_count=1,
+    )
+    client.poll_until_complete.return_value = final
+    client.fetch_results.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[],
+        returned_rows=2,
+    )
+
+    cursor.execute("SELECT name FROM huge_table")
+
+    assert cursor.get_query_status() is final
+    client.get_query_status.assert_not_called()
+
+
+def test_get_query_status_after_close_raises():
+    """A closed cursor must not return stale status."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    cursor.execute("SELECT 1")
+    cursor.close()
+
+    with pytest.raises(InterfaceError):
+        cursor.get_query_status()


### PR DESCRIPTION
Expose a non-blocking accessor on `Cursor` that returns the most recent
QueryStatus the server emitted for the current query. The status is
captured when `execute()` runs and again after the async polling loop
completes, so callers don't pay an extra HTTP call to read it.

The QueryStatus shape mirrors what Connect API V3 returns on
`GET /services/data/v*/ssot/query-sql/{queryId}` today: queryId,
completionStatus, progress, rowCount, chunkCount, expirationTime.