### PR TITLE
Expose server-side QueryStatus on Cursor

### DIFF
--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -52,6 +52,9 @@ from .types import BINARY, DATETIME, NUMBER, ROWID, STRING
 # Import and expose metadata structures
 from .metadata import DataCloudTable, Field
 
+# Import and expose query status structures (used by Cursor.get_query_status)
+from .api.models import ExecutionStatistics, QueryStatus
+
 # Import connection
 from .connection import Connection
 
@@ -206,6 +209,9 @@ __all__ = [
     # Metadata structures
     "DataCloudTable",
     "Field",
+    # Query status structures
+    "QueryStatus",
+    "ExecutionStatistics",
     # Authenticators (advanced usage)
     "UsernamePasswordAuthenticator",
     "JWTAuthenticator",

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
@@ -5,7 +5,50 @@ These models represent the structure of API responses from the Query API endpoin
 """
 
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, List, Optional
+
+
+@dataclass
+class ExecutionStatistics:
+    """
+    Server-side execution statistics for a query.
+
+    These fields capture wall-clock runtime, rows processed, and compilation
+    time for the query as measured on the server. The Connect API V3
+    `QuerySqlStatusRepresentation` does not yet surface them, so on Connect
+    today they are typically `None`; the model parses them when present so
+    the client is ready as soon as the server starts including them.
+    """
+
+    wall_clock_time: Optional[timedelta] = None
+    rows_processed: Optional[int] = None
+    compilation_time: Optional[timedelta] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ExecutionStatistics":
+        return cls(
+            wall_clock_time=_parse_duration(data.get("wallClockTime")),
+            rows_processed=data.get("rowsProcessed"),
+            compilation_time=_parse_duration(data.get("compilationTime")),
+        )
+
+
+def _parse_duration(value: Any) -> Optional[timedelta]:
+    """Parse a Connect-API duration value (milliseconds, seconds, or ISO 8601)."""
+    if value is None:
+        return None
+    if isinstance(value, timedelta):
+        return value
+    if isinstance(value, (int, float)):
+        # Convention: integer/float server values are milliseconds.
+        return timedelta(milliseconds=value)
+    if isinstance(value, str):
+        try:
+            return timedelta(milliseconds=float(value))
+        except ValueError:
+            return None
+    return None
 
 
 @dataclass
@@ -20,6 +63,9 @@ class QueryStatus:
         row_count: Total number of rows in the result set
         chunk_count: Number of chunks the results are divided into
         expiration_time: When the query results expire (if applicable)
+        execution_statistics: Server-side execution stats (wall-clock time,
+            rows processed). `None` when the server does not include them in
+            the response, which is the case for Connect API V3 today.
     """
     query_id: str
     completion_status: str
@@ -27,6 +73,7 @@ class QueryStatus:
     row_count: int
     chunk_count: int
     expiration_time: Optional[str] = None
+    execution_statistics: Optional[ExecutionStatistics] = None
 
     @classmethod
     def from_dict(cls, data: dict) -> "QueryStatus":
@@ -39,6 +86,7 @@ class QueryStatus:
         Returns:
             QueryStatus instance
         """
+        stats_data = data.get("executionStatistics")
         return cls(
             query_id=data.get("queryId", ""),
             completion_status=data.get("completionStatus", ""),
@@ -46,6 +94,9 @@ class QueryStatus:
             row_count=data.get("rowCount", 0),
             chunk_count=data.get("chunkCount", 0),
             expiration_time=data.get("expirationTime"),
+            execution_statistics=(
+                ExecutionStatistics.from_dict(stats_data) if stats_data else None
+            ),
         )
 
     def is_complete(self) -> bool:

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
@@ -7,7 +7,7 @@ The Cursor class executes queries and manages result retrieval.
 from typing import Any, Dict, List, Optional, Tuple
 
 from .api.client import DataCloudQueryClient
-from .api.models import ColumnMetadata
+from .api.models import ColumnMetadata, QueryStatus
 from .exceptions import InterfaceError, NotSupportedError
 from .types import build_description_tuple, convert_datacloud_value
 
@@ -40,6 +40,10 @@ class Cursor:
         self._description: Optional[List[Tuple]] = None
         self._rowcount: int = -1  # DB-API 2.0: -1 for SELECT, else number of rows affected
         self._closed: bool = False
+        # Latest QueryStatus observed on this cursor — refreshed by execute()
+        # and by the polling loop. Returned by get_query_status() without an
+        # extra HTTP call.
+        self._query_status: Optional[QueryStatus] = None
 
     @property
     def description(self) -> Optional[List[Tuple]]:
@@ -173,6 +177,7 @@ class Cursor:
         self._query_id = response.status.query_id
         self._metadata = response.metadata
         self._total_row_count = response.status.row_count
+        self._query_status = response.status
         self._rowcount = -1  # SELECT queries return -1
         self._build_description()
 
@@ -186,6 +191,7 @@ class Cursor:
             # Asynchronous response - need to poll until complete
             final_status = self._client.poll_until_complete(self._query_id)
             self._total_row_count = final_status.row_count
+            self._query_status = final_status
 
             # Fetch first chunk
             self._fetch_next_chunk()
@@ -322,6 +328,39 @@ class Cursor:
         self._check_query_executed()
 
         self._client.cancel_query(self._query_id)
+
+    def get_query_status(self) -> Optional[QueryStatus]:
+        """
+        Return the most recently observed QueryStatus for this cursor's query.
+
+        This is a non-blocking accessor — it does not issue an extra HTTP
+        call. The status is refreshed each time `execute()` runs and after
+        the async polling loop completes. It is the surface used to access
+        server-side execution statistics like wall-clock runtime and
+        rows-processed.
+
+        Note on availability today: Connect API V3 does not yet include
+        `executionStatistics` in the `QuerySqlStatusRepresentation` it returns,
+        so `status.execution_statistics` will typically be `None`. This
+        accessor is forward-compatible — once Connect surfaces those fields,
+        they will populate automatically without any client-side change.
+        Until then, callers can still use `row_count`, `progress`,
+        `chunk_count`, and `completion_status`.
+
+        Returns:
+            The latest QueryStatus, or None if no query has been executed.
+
+        Example:
+            cursor.execute("SELECT ...")
+            for _ in cursor:
+                pass
+            status = cursor.get_query_status()
+            stats = status.execution_statistics
+            if stats and stats.wall_clock_time is not None:
+                print(f"server runtime: {stats.wall_clock_time}")
+        """
+        self._check_closed()
+        return self._query_status
 
     def fetch_df(self):
         """

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -2,10 +2,16 @@
 Tests for Data Cloud Query API client.
 """
 
+from datetime import timedelta
+
 import pytest
 import responses
 
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
+from salesforce_datacloud_connector.api.models import (
+    ExecutionStatistics,
+    QueryStatus,
+)
 from salesforce_datacloud_connector.exceptions import ProgrammingError
 
 
@@ -367,3 +373,60 @@ def test_auth_token_included():
     )
 
     client.execute_query("SELECT 1")
+
+
+def test_query_status_without_execution_statistics():
+    """Connect API V3 today does not include `executionStatistics` — parsing
+    still succeeds and the field is left as None.
+    """
+    status = QueryStatus.from_dict(
+        {
+            "queryId": "q1",
+            "completionStatus": "Finished",
+            "progress": 1.0,
+            "rowCount": 1288,
+            "chunkCount": 1,
+            "expirationTime": "seconds: 1738344542\n",
+        }
+    )
+
+    assert status.is_complete()
+    assert status.row_count == 1288
+    assert status.execution_statistics is None
+
+
+def test_query_status_with_execution_statistics():
+    """When the server includes `executionStatistics`, it parses into an
+    ExecutionStatistics with timedelta wall-clock and integer rowsProcessed.
+    """
+    status = QueryStatus.from_dict(
+        {
+            "queryId": "q1",
+            "completionStatus": "Finished",
+            "progress": 1.0,
+            "rowCount": 1288,
+            "chunkCount": 1,
+            "executionStatistics": {
+                "wallClockTime": 42,
+                "rowsProcessed": 1288,
+                "compilationTime": 7,
+            },
+        }
+    )
+
+    stats = status.execution_statistics
+    assert isinstance(stats, ExecutionStatistics)
+    assert stats.wall_clock_time == timedelta(milliseconds=42)
+    assert stats.rows_processed == 1288
+    assert stats.compilation_time == timedelta(milliseconds=7)
+
+
+def test_execution_statistics_partial_fields():
+    """Missing fields stay None — the model never assumes a server contract
+    that the V3 spec hasn't pinned down yet.
+    """
+    stats = ExecutionStatistics.from_dict({"rowsProcessed": 5})
+
+    assert stats.wall_clock_time is None
+    assert stats.rows_processed == 5
+    assert stats.compilation_time is None

--- a/salesforce_datacloud_connector/tests/test_cursor.py
+++ b/salesforce_datacloud_connector/tests/test_cursor.py
@@ -6,8 +6,15 @@ from unittest.mock import Mock
 
 import pytest
 
+from datetime import timedelta
+
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
-from salesforce_datacloud_connector.api.models import ColumnMetadata, QueryResponse, QueryStatus
+from salesforce_datacloud_connector.api.models import (
+    ColumnMetadata,
+    ExecutionStatistics,
+    QueryResponse,
+    QueryStatus,
+)
 from salesforce_datacloud_connector.cursor import Cursor
 from salesforce_datacloud_connector.exceptions import InterfaceError, NotSupportedError
 
@@ -394,3 +401,131 @@ def test_fetch_before_execute():
 
     with pytest.raises(InterfaceError):
         cursor.fetchmany(10)
+
+
+def test_get_query_status_before_execute():
+    """get_query_status() returns None before any query has run."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    assert cursor.get_query_status() is None
+
+
+def test_get_query_status_after_sync_execute():
+    """For a synchronous query, returns the status from the initial response."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    status = QueryStatus(
+        query_id="q1",
+        completion_status="ResultsProduced",
+        progress=1.0,
+        row_count=2,
+        chunk_count=1,
+    )
+    client.execute_query.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=2,
+        status=status,
+    )
+
+    cursor.execute("SELECT name FROM users")
+
+    observed = cursor.get_query_status()
+    assert observed is status
+    # Non-blocking: get_query_status() must NOT issue a status HTTP call.
+    client.get_query_status.assert_not_called()
+
+
+def test_get_query_status_after_async_poll():
+    """For an async query, returns the final polled status, not the initial Running one."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="Running",
+            progress=0.1,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    final = QueryStatus(
+        query_id="q1",
+        completion_status="Finished",
+        progress=1.0,
+        row_count=2,
+        chunk_count=1,
+    )
+    client.poll_until_complete.return_value = final
+    client.fetch_results.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[],
+        returned_rows=2,
+    )
+
+    cursor.execute("SELECT name FROM huge_table")
+
+    assert cursor.get_query_status() is final
+    client.get_query_status.assert_not_called()
+
+
+def test_get_query_status_surfaces_execution_statistics():
+    """When the server includes executionStatistics, it is reachable through the cursor."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    stats = ExecutionStatistics(
+        wall_clock_time=timedelta(milliseconds=42),
+        rows_processed=1288,
+    )
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=0,
+            chunk_count=0,
+            execution_statistics=stats,
+        ),
+    )
+
+    cursor.execute("SELECT 1")
+
+    observed = cursor.get_query_status()
+    assert observed is not None
+    assert observed.execution_statistics is stats
+    assert observed.execution_statistics.wall_clock_time == timedelta(milliseconds=42)
+    assert observed.execution_statistics.rows_processed == 1288
+
+
+def test_get_query_status_after_close_raises():
+    """A closed cursor must not return stale status."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    cursor.execute("SELECT 1")
+    cursor.close()
+
+    with pytest.raises(InterfaceError):
+        cursor.get_query_status()


### PR DESCRIPTION
Add a non-blocking `Cursor.get_query_status()` accessor on the v2 beta `salesforce-datacloud-connector` package that returns the most recent QueryStatus observed for the cursor's query. The status is refreshed when execute() runs and after the async polling loop completes; the accessor itself never issues an extra RPC.

Introduce an `ExecutionStatistics` dataclass (wall_clock_time, rows_processed, compilation_time) and an optional
`execution_statistics` field on `QueryStatus`. The Connect API V3 representation does not yet include this block, so today's responses parse with `execution_statistics=None`; once the server starts sending it, callers will receive it without any client-side change.

Re-export `QueryStatus` and `ExecutionStatistics` at the package level. Tests cover the sync path, async polling path, partial-payload parsing, and that the accessor stays non-blocking.