### PR TITLE
Run v1 Python package CI on all PRs

### DIFF
--- a/.github/workflows/v1-package.yml
+++ b/.github/workflows/v1-package.yml
@@ -1,6 +1,6 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 
-name: Python package
+name: v1 Package - test and lint
 
 on:
   push:

--- a/.github/workflows/v1-package.yml
+++ b/.github/workflows/v1-package.yml
@@ -5,22 +5,8 @@ name: Python package
 on:
   push:
     branches: [ master ]
-    paths:
-      - 'salesforcecdpconnector/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'example.py'
-      - '.github/workflows/v1-package.yml'
   pull_request:
     branches: [ master ]
-    paths:
-      - 'salesforcecdpconnector/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'example.py'
-      - '.github/workflows/v1-package.yml'
 
 jobs:
   build:

--- a/.github/workflows/v2-package.yml
+++ b/.github/workflows/v2-package.yml
@@ -3,14 +3,8 @@ name: v2 Package - test and lint
 on:
   push:
     branches: [master]
-    paths:
-      - 'salesforce_datacloud_connector/**'
-      - '.github/workflows/v2-package.yml'
   pull_request:
     branches: [master]
-    paths:
-      - 'salesforce_datacloud_connector/**'
-      - '.github/workflows/v2-package.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Drop the path filter on the v1 `Python package` workflow so its build (3.x) matrix runs on every PR/push to master. The filter previously skipped v1 CI for PRs touching only the v2 package, but GitHub still listed `build (3.x)` as expected/required because it had been recorded on master HEAD by earlier v1 runs. PRs that didn't touch v1 paths could never resolve those expectations and the merge gate stayed blocked.

The cost (~1 min of CI on v2-only PRs) is worth not having to maintain two parallel "expected check" lists between protection rules and path-filtered workflows.