### PR TITLE
Migrate v2 Python connector to off-core Query v3 REST API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
       - "dependencies"
       - "v1-deprecated"
       - "automated"
-    reviewers:
-      - "salesforce/data-cloud-connectors"
     groups:
       v1-minor-and-patch:
         patterns:
@@ -49,8 +47,6 @@ updates:
       - "dependencies"
       - "v2"
       - "automated"
-    reviewers:
-      - "salesforce/data-cloud-connectors"
     groups:
       v2-minor-and-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+
+# Dependabot for salesforce-datacloud-connector (v1 + v2 dual-tree structure)
+# - v1 (deprecated): Root directory, maintenance-only, majors ignored
+# - v2 (active): salesforce_datacloud_connector subdirectory, full updates
+# - GitHub Actions: Workflow dependency updates
+
+updates:
+  # V1 Python dependencies (deprecated, root directory)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    commit-message:
+      prefix: "deps(v1):"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "v1-deprecated"
+      - "automated"
+    reviewers:
+      - "salesforce/data-cloud-connectors"
+    groups:
+      v1-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # V1 is deprecated - ignore all major version updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 5
+
+  # V2 Python dependencies (active, subdirectory)
+  - package-ecosystem: "pip"
+    directory: "/salesforce_datacloud_connector"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    commit-message:
+      prefix: "deps(v2):"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "v2"
+      - "automated"
+    reviewers:
+      - "salesforce/data-cloud-connectors"
+    groups:
+      v2-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Allow major updates for v2 (do not ignore them)
+    open-pull-requests-limit: 10
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    commit-message:
+      prefix: "deps(actions):"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "automated"
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,8 @@ dmypy.json
 # Mac files
 .DS_Store
 
+# Internal planning / design docs — must NOT be pushed to the public OSS repo
+/262-connectors-python-plan.md
+/official/
+/docs/superpowers/
+

--- a/.gitignore
+++ b/.gitignore
@@ -134,9 +134,3 @@ dmypy.json
 # Mac files
 .DS_Store
 
-# Internal planning / design docs — must NOT be pushed to the public OSS repo
-/262-connectors-python-plan.md
-/official/
-/docs/superpowers/
-/.superpowers/
-

--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ dmypy.json
 /262-connectors-python-plan.md
 /official/
 /docs/superpowers/
+/.superpowers/
 

--- a/salesforce_datacloud_connector/README.md
+++ b/salesforce_datacloud_connector/README.md
@@ -449,45 +449,6 @@ and `pytest -m "not e2e"` locally.
 See [`CONTRIBUTING.md`](../CONTRIBUTING.md) at the repo root for the full
 contribution guide.
 
-## Demo
-
-An interactive Jupyter notebook demo (`demo.ipynb`) is available in the
-companion `sfdc-connector-sample` harness — a standalone project that installs
-this connector and exercises it against a live Data Cloud org.
-
-**To run the demo:**
-
-1. Obtain the `sfdc-connector-sample` harness and change into it.
-
-2. Set up your environment (copy `.env.example` to `.env` and fill in your
-   credentials — the harness authenticates with the `username_password` flow by
-   default; JWT bearer token is the recommended production flow):
-
-   ```bash
-   cp .env.example .env
-   # Edit .env with your credentials
-   uv sync
-   ```
-
-3. Launch Jupyter and open `demo.ipynb`:
-
-   ```bash
-   uv run jupyter notebook demo.ipynb
-   ```
-
-The notebook demonstrates:
-- Connecting to a live Data Cloud org
-- Basic queries (`SELECT`, `COUNT`, `WHERE`, `GROUP BY`, `ORDER BY`)
-- Fetch methods (`fetchone`, `fetchmany`, `fetchall`, iteration)
-- Pandas integration (`cursor.fetch_df()`, `pandas.read_sql()`)
-- Type mapping and cursor metadata
-- Error handling
-
-Regardless of the core auth flow, queries run against the off-core Query v3
-REST API, so the demo validates the full off-core path. Many of the sample
-tests use synthetic queries (`generate_series`) that work on any Data Cloud org
-without requiring specific tables or data.
-
 ## License
 
 BSD-3-Clause. See [`LICENSE.txt`](../LICENSE.txt) at the repo root.

--- a/salesforce_datacloud_connector/README.md
+++ b/salesforce_datacloud_connector/README.md
@@ -429,6 +429,45 @@ and `pytest -m "not e2e"` locally.
 See [`CONTRIBUTING.md`](../CONTRIBUTING.md) at the repo root for the full
 contribution guide.
 
+## Demo
+
+An interactive Jupyter notebook demo (`demo.ipynb`) is available in the
+companion `sfdc-connector-sample` harness — a standalone project that installs
+this connector and exercises it against a live Data Cloud org.
+
+**To run the demo:**
+
+1. Obtain the `sfdc-connector-sample` harness and change into it.
+
+2. Set up your environment (copy `.env.example` to `.env` and fill in your
+   credentials — the harness authenticates with the `username_password` flow by
+   default; JWT bearer token is the recommended production flow):
+
+   ```bash
+   cp .env.example .env
+   # Edit .env with your credentials
+   uv sync
+   ```
+
+3. Launch Jupyter and open `demo.ipynb`:
+
+   ```bash
+   uv run jupyter notebook demo.ipynb
+   ```
+
+The notebook demonstrates:
+- Connecting to a live Data Cloud org
+- Basic queries (`SELECT`, `COUNT`, `WHERE`, `GROUP BY`, `ORDER BY`)
+- Fetch methods (`fetchone`, `fetchmany`, `fetchall`, iteration)
+- Pandas integration (`cursor.fetch_df()`, `pandas.read_sql()`)
+- Type mapping and cursor metadata
+- Error handling
+
+Regardless of the core auth flow, queries run against the off-core Query v3
+REST API, so the demo validates the full off-core path. Many of the sample
+tests use synthetic queries (`generate_series`) that work on any Data Cloud org
+without requiring specific tables or data.
+
 ## License
 
 BSD-3-Clause. See [`LICENSE.txt`](../LICENSE.txt) at the repo root.

--- a/salesforce_datacloud_connector/README.md
+++ b/salesforce_datacloud_connector/README.md
@@ -9,13 +9,17 @@ This package (`salesforce-datacloud-connector`) supersedes the
 `salesforce-cdp-connector` package. New projects should adopt this package;
 existing `salesforce-cdp-connector` users should plan to migrate.
 
+**Current version:** `2.0.0b2` (beta 2, off-core Query v3 migration)
+
 [![Python Version](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-green.svg)](../LICENSE.txt)
 
 ## Important: this is a beta release
 
-`salesforce-datacloud-connector` is currently published as a **beta** on PyPI
-(`2.0.0b1`). The public API surface may change before the GA release.
+`salesforce-datacloud-connector` is currently published as **version 2.0.0b2
+(beta 2)** on PyPI. This release replatforms query execution onto the off-core
+Query v3 REST API. The public DB-API 2.0 surface is stable, but the package is
+still in beta to allow for adjustments based on field feedback.
 
 - Install with the `--pre` flag — pip will not pick up pre-releases otherwise:
 
@@ -27,7 +31,7 @@ existing `salesforce-cdp-connector` users should plan to migrate.
   manifests:
 
   ```text
-  salesforce-datacloud-connector==2.0.0b1
+  salesforce-datacloud-connector==2.0.0b2
   ```
 
   This protects you from accidental upgrades to a later beta or release
@@ -73,31 +77,35 @@ Optional (under `[pandas]` extra):
 
 ## Quickstart
 
+The connector uses OAuth for authentication. **JWT bearer token** is the
+recommended flow for production and demo environments:
+
 ```python
 import salesforce_datacloud_connector as sfdc
 
-# Connect to Salesforce Data Cloud (refresh token flow shown — see below for
-# all three flows)
+# Read private key from file (PEM format)
+with open("private_key.pem", "r") as f:
+    private_key = f.read()
+
 conn = sfdc.connect(
     login_url="https://login.salesforce.com",
-    auth_type="refresh_token",
-    client_id="YOUR_CLIENT_ID",
-    client_secret="YOUR_CLIENT_SECRET",
-    refresh_token="YOUR_REFRESH_TOKEN",
+    auth_type="jwt",
+    username="your_user@example.com",
+    client_id="YOUR_CONNECTED_APP_CLIENT_ID",
+    jwt_private_key=private_key,
 )
 
 cursor = conn.cursor()
-cursor.execute("SELECT Id, Name FROM Account LIMIT 10")
-
-for row in cursor:
-    print(row)
+cursor.execute("SELECT COUNT(*) FROM Account")
+(count,) = cursor.fetchone()
+print(f"Total accounts: {count}")
 
 cursor.close()
 conn.close()
 ```
 
-The connector also supports the standard Python context-manager idioms — both
-the connection and the cursor close cleanly when their `with` blocks exit:
+The connector also supports context managers — both the connection and the cursor
+close cleanly when their `with` blocks exit:
 
 ```python
 import salesforce_datacloud_connector as sfdc
@@ -114,22 +122,11 @@ with sfdc.connect(...) as conn:
 The connector ships three OAuth flows, all driven through `sfdc.connect(...)`
 via the `auth_type` keyword.
 
-### Username / Password
+### JWT Bearer Token (recommended)
 
-```python
-import salesforce_datacloud_connector as sfdc
-
-conn = sfdc.connect(
-    login_url="https://login.salesforce.com",
-    auth_type="username_password",
-    username="user@example.com",
-    password="your_password",
-    client_id="your_connected_app_client_id",
-    client_secret="your_connected_app_client_secret",
-)
-```
-
-### JWT Bearer Token
+JWT bearer token is the recommended flow for production services and demos.
+It requires a connected app configured with a certificate and the `api`,
+`cdpquery`, and `refresh_token offline_access` scopes.
 
 ```python
 import salesforce_datacloud_connector as sfdc
@@ -146,6 +143,12 @@ conn = sfdc.connect(
 )
 ```
 
+**Setup:**
+1. Create a connected app in Salesforce Setup → App Manager
+2. Enable OAuth Settings, configure callback URL, add `api`, `cdpquery`, `refresh_token offline_access` scopes
+3. Enable "Use digital signatures" and upload a certificate (self-signed is fine for dev)
+4. Extract the private key to a PEM file: `openssl pkcs12 -in cert.p12 -nocerts -nodes -out private_key.pem`
+
 ### Refresh Token (recommended for long-running services)
 
 ```python
@@ -159,6 +162,24 @@ conn = sfdc.connect(
     client_id=os.environ["SFDC_CLIENT_ID"],
     client_secret=os.environ["SFDC_CLIENT_SECRET"],
     refresh_token=os.environ["SFDC_REFRESH_TOKEN"],
+)
+```
+
+### Username/Password (deprecated)
+
+Username/password authentication is **deprecated** and will be removed in a
+future release. Use JWT bearer token or refresh token flows instead.
+
+```python
+import salesforce_datacloud_connector as sfdc
+
+conn = sfdc.connect(
+    login_url="https://login.salesforce.com",
+    auth_type="username_password",
+    username="user@example.com",
+    password="your_password",
+    client_id="your_connected_app_client_id",
+    client_secret="your_connected_app_client_secret",
 )
 ```
 
@@ -338,7 +359,7 @@ command above.
 
 ## Beta-period limitations
 
-`2.0.0b1` is intentionally scoped:
+`2.0.0b2` is intentionally scoped:
 
 1. **Read-only** — no `INSERT`, `UPDATE`, `DELETE`, or DDL operations.
 2. **No streaming** — results buffer in memory (chunked pagination keeps

--- a/salesforce_datacloud_connector/README.md
+++ b/salesforce_datacloud_connector/README.md
@@ -40,7 +40,7 @@ still in beta to allow for adjustments based on field feedback.
 ## Features
 
 - **DB-API 2.0 compliant** — standard Python database interface.
-- **Three OAuth flows** — Username/Password, JWT Bearer Token, Refresh Token.
+- **Four OAuth flows** — JWT Bearer Token, Refresh Token, Client Credentials, Username/Password.
 - **Pandas integration** — works with `pandas.read_sql()` and
   `cursor.fetch_df()` (under the `[pandas]` extra).
 - **Notebook-ready** — interactive exploration and visualization in Jupyter.
@@ -119,7 +119,7 @@ with sfdc.connect(...) as conn:
 
 ## Authentication
 
-The connector ships three OAuth flows, all driven through `sfdc.connect(...)`
+The connector ships four OAuth flows, all driven through `sfdc.connect(...)`
 via the `auth_type` keyword.
 
 ### JWT Bearer Token (recommended)
@@ -162,6 +162,26 @@ conn = sfdc.connect(
     client_id=os.environ["SFDC_CLIENT_ID"],
     client_secret=os.environ["SFDC_CLIENT_SECRET"],
     refresh_token=os.environ["SFDC_REFRESH_TOKEN"],
+)
+```
+
+### Client Credentials
+
+Client Credentials is a server-to-server flow with no user context — the
+connected app itself is the principal. It requires only a client ID and
+secret, and the connected app must be configured to allow the client
+credentials flow.
+
+```python
+import os
+
+import salesforce_datacloud_connector as sfdc
+
+conn = sfdc.connect(
+    login_url="https://login.salesforce.com",
+    auth_type="client_credentials",
+    client_id=os.environ["SFDC_CLIENT_ID"],
+    client_secret=os.environ["SFDC_CLIENT_SECRET"],
 )
 ```
 

--- a/salesforce_datacloud_connector/pyproject.toml
+++ b/salesforce_datacloud_connector/pyproject.toml
@@ -24,6 +24,7 @@ pandas = ["pandas>=2.0.0", "pyarrow>=14.0.0"]
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
+    "pyyaml>=6.0.0",
     "responses>=0.23.0",
     "ruff>=0.1.0",
     "tomli>=2.0.0; python_version<'3.11'",

--- a/salesforce_datacloud_connector/pyproject.toml
+++ b/salesforce_datacloud_connector/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "salesforce-datacloud-connector"
-version = "2.0.0b1"
+version = "2.0.0b2"
 description = "Salesforce Data Cloud Python connector (V3 driver, beta)"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -26,6 +26,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "responses>=0.23.0",
     "ruff>=0.1.0",
+    "tomli>=2.0.0; python_version<'3.11'",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -189,7 +189,6 @@ def connect(
         )
 
     # Wrap authenticator in token exchanger for CDP token + tenant endpoint
-    from .auth.token_exchanger import DataCloudTokenExchanger
     exchanger = DataCloudTokenExchanger(
         core_authenticator=authenticator,
         dataspace=dataspace,

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -237,4 +237,4 @@ __all__ = [
 ]
 
 # Package metadata
-__version__ = "0.1.0"
+__version__ = "2.0.0b2"

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -57,10 +57,14 @@ from .connection import Connection
 
 # Import authenticators
 from .auth.oauth import (
+    ClientCredentialsAuthenticator,
     JWTAuthenticator,
     RefreshTokenAuthenticator,
     UsernamePasswordAuthenticator,
 )
+
+# Import token exchanger
+from .auth.token_exchanger import DataCloudTokenExchanger
 
 
 def connect(
@@ -85,7 +89,7 @@ def connect(
     Args:
         login_url: Salesforce login URL (default: "https://login.salesforce.com")
                   Use "https://test.salesforce.com" for sandboxes
-        auth_type: Authentication type - "username_password", "jwt", or "refresh_token"
+        auth_type: Authentication type - "username_password", "jwt", "refresh_token", or "client_credentials"
         username: Salesforce username (required for username_password and jwt)
         password: Salesforce password (required for username_password)
         client_id: Connected app client ID (required for all auth types)
@@ -167,14 +171,32 @@ def connect(
             refresh_token=refresh_token,
         )
 
+    elif auth_type == "client_credentials":
+        if not all([client_id, client_secret]):
+            raise ValueError(
+                "client_credentials auth requires: client_id, client_secret"
+            )
+        authenticator = ClientCredentialsAuthenticator(
+            login_url=login_url,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
     else:
         raise ValueError(
             f"Invalid auth_type: {auth_type}. "
-            f"Must be 'username_password', 'jwt', or 'refresh_token'"
+            f"Must be 'username_password', 'jwt', 'refresh_token', or 'client_credentials'"
         )
 
-    # Create and return connection
-    return Connection(authenticator, dataspace=dataspace, workload=workload)
+    # Wrap authenticator in token exchanger for CDP token + tenant endpoint
+    from .auth.token_exchanger import DataCloudTokenExchanger
+    exchanger = DataCloudTokenExchanger(
+        core_authenticator=authenticator,
+        dataspace=dataspace,
+    )
+
+    # Create and return connection with exchanger
+    return Connection(exchanger, dataspace=dataspace, workload=workload)
 
 
 # Public API
@@ -210,6 +232,8 @@ __all__ = [
     "UsernamePasswordAuthenticator",
     "JWTAuthenticator",
     "RefreshTokenAuthenticator",
+    "ClientCredentialsAuthenticator",
+    "DataCloudTokenExchanger",
 ]
 
 # Package metadata

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -52,6 +52,9 @@ from .types import BINARY, DATETIME, NUMBER, ROWID, STRING
 # Import and expose metadata structures
 from .metadata import DataCloudTable, Field
 
+# Import and expose query status structure (used by Cursor.get_query_status)
+from .api.models import QueryStatus
+
 # Import connection
 from .connection import Connection
 
@@ -227,6 +230,8 @@ __all__ = [
     # Metadata structures
     "DataCloudTable",
     "Field",
+    # Query status structure
+    "QueryStatus",
     # Authenticators (advanced usage)
     "UsernamePasswordAuthenticator",
     "JWTAuthenticator",

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/_metadata_pg.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/_metadata_pg.py
@@ -201,7 +201,7 @@ def _build_tables_query(
     # The v3 query client sends positional (qmark) parameters, so placeholders
     # must be ? — a :named placeholder makes the server reject the query with
     # "conflicting parameter style 'named' ... set to 'qmark'". Insertion order
-    # (schema before table) matches the positional array _convert_parameters builds.
+    # (schema before table) matches the positional array _bind_parameters builds.
     if schema_pattern:
         sql += " AND n.nspname LIKE ?"
         params["schema_pattern"] = schema_pattern

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/_metadata_pg.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/_metadata_pg.py
@@ -198,12 +198,16 @@ def _build_tables_query(
     sql = GET_TABLES_QUERY
     params = {}
 
+    # The v3 query client sends positional (qmark) parameters, so placeholders
+    # must be ? — a :named placeholder makes the server reject the query with
+    # "conflicting parameter style 'named' ... set to 'qmark'". Insertion order
+    # (schema before table) matches the positional array _convert_parameters builds.
     if schema_pattern:
-        sql += " AND n.nspname LIKE :schema_pattern"
+        sql += " AND n.nspname LIKE ?"
         params["schema_pattern"] = schema_pattern
 
     if table_name_pattern:
-        sql += " AND c.relname LIKE :table_name_pattern"
+        sql += " AND c.relname LIKE ?"
         params["table_name_pattern"] = table_name_pattern
 
     if table_types:
@@ -231,12 +235,13 @@ def _build_columns_query(
     sql = GET_COLUMNS_QUERY
     params = {}
 
+    # Positional (qmark) placeholders for v3; see _build_tables_query.
     if schema_pattern:
-        sql += " AND n.nspname LIKE :schema_pattern"
+        sql += " AND n.nspname LIKE ?"
         params["schema_pattern"] = schema_pattern
 
     if table_name_pattern:
-        sql += " AND c.relname LIKE :table_name_pattern"
+        sql += " AND c.relname LIKE ?"
         params["table_name_pattern"] = table_name_pattern
 
     sql += " ORDER BY n.nspname, c.relname, a.attnum"

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -9,14 +9,21 @@ This module implements the v3 REST transport layer for the Query API:
 - poll_until_complete: blocking poll until a query completes
 """
 
+import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from ..exceptions import OperationalError, map_http_error_to_exception
+from ..exceptions import OperationalError, ProgrammingError, map_http_error_to_exception
 from ..types import infer_sql_parameter_type
 from .models import QueryResponse, QueryStatus
+
+# Matches a :name placeholder while ignoring PostgreSQL ::type casts. The
+# negative lookbehind (?<![:\w]) rejects the second colon of "::" and any
+# colon glued to an identifier, so "value::regclass" is left untouched but
+# "= :kind" is captured.
+_NAMED_PARAM_RE = re.compile(r"(?<![:\w]):(\w+)")
 
 
 class DataCloudQueryClient:
@@ -152,31 +159,60 @@ class DataCloudQueryClient:
         )
         raise exception
 
-    def _convert_parameters(self, params: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """
-        Convert Python dict parameters to v3 parameters array format.
+    @staticmethod
+    def _param_entry(value: Any) -> Dict[str, Any]:
+        """Build one v3 parameter entry: {"type": <lowercase>, "value": ...}."""
+        return {"type": infer_sql_parameter_type(value).lower(), "value": value}
 
-        V3 uses positional parameters (question-mark style), so only type and value are sent.
+    def _bind_parameters(
+        self, sql: str, params: Optional[Dict[str, Any]]
+    ) -> Tuple[str, List[Dict[str, Any]]]:
+        """
+        Prepare SQL and parameters for v3, which accepts only positional
+        (question-mark) parameters.
+
+        The driver advertises paramstyle="named", so callers write :name
+        placeholders with a values dict. v3 rejects named placeholders
+        ("conflicting parameter style 'named' ... set to 'qmark'"), so each
+        :name is rewritten to ? and its value emitted positionally in the order
+        the placeholders appear in the SQL. A name used N times expands to N
+        question marks and N repeated values.
+
+        SQL that already uses ? placeholders (e.g. internal catalog queries)
+        contains no :name tokens: it is passed through unchanged and the value
+        array is built from the dict's insertion order.
 
         Args:
-            params: Dictionary of named parameters (names ignored in v3)
+            sql: Query text with :name and/or ? placeholders
+            params: Values dict (names match the :name placeholders)
 
         Returns:
-            List of parameter dictionaries in v3 API format: [{"type": "varchar", "value": "..."}]
+            (sql_with_qmarks, positional_parameter_array)
+
+        Raises:
+            ProgrammingError: If the SQL references a :name absent from params
         """
         if not params:
-            return []
+            return sql, []
 
-        sql_params = []
-        for name, value in params.items():
-            param_type = infer_sql_parameter_type(value)
-            # V3 parameter format: {"type": "varchar", "value": "..."} (lowercase type)
-            sql_params.append({
-                "type": param_type.lower(),
-                "value": value,
-            })
+        # No :name placeholders → qmark-style SQL: positional array from dict order.
+        if not _NAMED_PARAM_RE.search(sql):
+            return sql, [self._param_entry(v) for v in params.values()]
 
-        return sql_params
+        sql_params: List[Dict[str, Any]] = []
+
+        def _replace(match: "re.Match") -> str:
+            name = match.group(1)
+            if name not in params:
+                raise ProgrammingError(
+                    f"No value supplied for named parameter ':{name}'"
+                )
+            sql_params.append(self._param_entry(params[name]))
+            return "?"
+
+        # re.sub invokes _replace left-to-right, so sql_params ends up in SQL order.
+        new_sql = _NAMED_PARAM_RE.sub(_replace, sql)
+        return new_sql, sql_params
 
     def execute_query(
         self,
@@ -199,15 +235,18 @@ class DataCloudQueryClient:
             ProgrammingError: For SQL syntax errors (400)
             OperationalError: For auth/network failures (401, 403, 500+)
         """
+        # v3 accepts only positional (qmark) parameters; rewrite any :name
+        # placeholders and build the positional array in SQL order.
+        sql, sql_params = self._bind_parameters(sql, parameters)
+
         request_body = {
             "sql": sql,
             "transferMode": "ADAPTIVE",
             "queryRowLimit": row_limit,
         }
 
-        # Add parameters if provided (v3 uses positional parameters)
-        if parameters:
-            request_body["parameters"] = self._convert_parameters(parameters)
+        if sql_params:
+            request_body["parameters"] = sql_params
 
         response = self._make_request("POST", self._base_url, json_data=request_body)
 

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -296,7 +296,7 @@ class DataCloudQueryClient:
 
     def cancel_query(self, query_id: str):
         """
-        Cancel a running query (cancelSqlQuery endpoint).
+        Cancel a running query via DELETE /api/v3/query/{queryId}.
 
         Args:
             query_id: Query ID to cancel

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -9,6 +9,7 @@ This module implements the v3 REST transport layer for the Query API:
 - poll_until_complete: blocking poll until a query completes
 """
 
+import json
 import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -261,7 +262,6 @@ class DataCloudQueryClient:
         if not status_header:
             raise OperationalError("Missing x-hyperdb-status header in query response")
 
-        import json
         status_data = json.loads(status_header)
         query_response.status = QueryStatus.from_dict(status_data)
 
@@ -297,7 +297,6 @@ class DataCloudQueryClient:
         if not status_header:
             raise OperationalError("Missing x-hyperdb-status header in response")
 
-        import json
         status_data = json.loads(status_header)
         return QueryStatus.from_dict(status_data)
 

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -1,12 +1,12 @@
 """
-HTTP client for Salesforce Data Cloud Query API.
+HTTP client for Salesforce Data Cloud off-core Query v3 REST API.
 
-This module handles all REST API calls to the Query API endpoints:
-- Execute queries (createSqlQuery)
-- Check query status (getSqlQuery)
-- Fetch results (getSqlQueryRows)
-- Cancel queries (cancelSqlQuery)
-- Fetch table metadata (getTableMetadata)
+This module implements the v3 REST transport layer for the Query API:
+- execute_query: POST /api/v3/query
+- get_query_status: GET /api/v3/query/{id}
+- fetch_results: GET /api/v3/query/{id}/rows
+- cancel_query: DELETE /api/v3/query/{id}
+- poll_until_complete: blocking poll until a query completes
 """
 
 import time
@@ -215,12 +215,16 @@ class DataCloudQueryClient:
         body = response.json()
         query_response = QueryResponse.from_dict(body)
 
-        # Parse status from x-hyperdb-status header (v3)
+        # Parse status from x-hyperdb-status header (v3). The header carries the
+        # queryId/rowCount/completionStatus the cursor relies on; the body never
+        # contains status in v3, so a missing header is a hard error, not None.
         status_header = response.headers.get("x-hyperdb-status")
-        if status_header:
-            import json
-            status_data = json.loads(status_header)
-            query_response.status = QueryStatus.from_dict(status_data)
+        if not status_header:
+            raise OperationalError("Missing x-hyperdb-status header in query response")
+
+        import json
+        status_data = json.loads(status_header)
+        query_response.status = QueryStatus.from_dict(status_data)
 
         return query_response
 

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -224,14 +224,14 @@ class DataCloudQueryClient:
         self, query_id: str, wait_time_ms: Optional[int] = None
     ) -> QueryStatus:
         """
-        Get query status (getSqlQuery endpoint).
+        Get query status via GET /api/v3/query/{queryId}.
 
         Args:
             query_id: Query ID from execute_query
             wait_time_ms: Milliseconds to wait before returning (long-polling, max 10000)
 
         Returns:
-            QueryStatus object
+            QueryStatus object (parsed from x-hyperdb-status header)
 
         Raises:
             OperationalError: For network failures
@@ -244,8 +244,15 @@ class DataCloudQueryClient:
             params["waitTimeMs"] = min(wait_time_ms, self.MAX_WAIT_TIME_MS)
 
         response = self._make_request("GET", url, params=params)
-        data = response.json()
-        return QueryStatus.from_dict(data.get("status", {}))
+
+        # Parse status from x-hyperdb-status header (v3)
+        status_header = response.headers.get("x-hyperdb-status")
+        if not status_header:
+            raise OperationalError("Missing x-hyperdb-status header in response")
+
+        import json
+        status_data = json.loads(status_header)
+        return QueryStatus.from_dict(status_data)
 
     def fetch_results(
         self,

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -136,7 +136,11 @@ class DataCloudQueryClient:
             raise OperationalError(f"Request failed: {e}") from e
 
     def _raise_api_error(self, response: requests.Response):
-        """Raise appropriate exception for API error response."""
+        """
+        Raise appropriate exception for API error response.
+
+        V3 error body: {"timestamp", "error", "message", "path", "tenantId", "internalErrorCode", "details"}
+        """
         try:
             error_data = response.json()
             error_message = error_data.get("message", response.text)

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -27,9 +27,6 @@ class DataCloudQueryClient:
     Includes automatic retry logic for transient failures.
     """
 
-    # API version to use (matches reference Java implementation)
-    API_VERSION = "v64.0"
-
     # Retry configuration
     MAX_RETRIES = 3
     RETRY_WAIT_SECONDS = 5
@@ -39,35 +36,42 @@ class DataCloudQueryClient:
 
     def __init__(
         self,
-        instance_url: str,
+        tenant_endpoint: str,
         auth_token_getter: callable,
         dataspace: Optional[str] = None,
         workload: Optional[str] = None,
     ):
         """
-        Initialize the API client.
+        Initialize the API client for off-core Query v3.
 
         Args:
-            instance_url: Salesforce instance URL
-            auth_token_getter: Callable that returns a valid OAuth token
+            tenant_endpoint: Data Cloud tenant endpoint (e.g., https://{tenant}.c360a.salesforce.com)
+            auth_token_getter: Callable that returns a valid CDP token
             dataspace: Data space name (default: "default")
-            workload: Optional workload name for logging/debugging
+            workload: Optional workload name for observability
         """
-        self.instance_url = instance_url.rstrip("/")
+        self.tenant_endpoint = tenant_endpoint.rstrip("/")
         self.auth_token_getter = auth_token_getter
-        self.dataspace = dataspace
+        self.dataspace = dataspace or "default"
         self.workload = workload
-        self._base_url = f"{self.instance_url}/services/data/{self.API_VERSION}/ssot/query-sql"
+        self._base_url = f"{self.tenant_endpoint}/api/v3/query"
 
     def _get_headers(self) -> Dict[str, str]:
-        """Get headers for API requests, including auth token and dataspace."""
+        """Get headers for v3 API requests."""
         token = self.auth_token_getter()
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            "ctx-dataspace-ds_name": self.dataspace,
         }
-        if self.dataspace:
-            headers["dataspace"] = self.dataspace
+
+        # Add workload header if specified
+        if self.workload:
+            headers["x-hyperdb-workload"] = f"python-connector-v2_{self.workload}"
+        else:
+            headers["x-hyperdb-workload"] = "python-connector-v2"
+
         return headers
 
     def _make_request(

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -262,36 +262,33 @@ class DataCloudQueryClient:
         omit_schema: bool = True,
     ) -> QueryResponse:
         """
-        Fetch query results (getSqlQueryRows endpoint).
+        Fetch query results via GET /api/v3/query/{queryId}/rows.
 
         Args:
-            query_id: Query ID from execute_query
-            offset: Starting row number (0-based)
-            row_limit: Maximum rows to return (server determines actual chunk size ~2MB)
-            omit_schema: If True, don't return metadata (reduces response size)
+            query_id: Query ID
+            offset: Starting row number (0-based, required in v3)
+            row_limit: Maximum rows to return (default: 1000000, server may limit)
+            omit_schema: If True, omit metadata in response (not used in v3, kept for compatibility)
 
         Returns:
             QueryResponse with rows
 
         Raises:
-            ProgrammingError: If offset is out of range
+            ProgrammingError: If offset is out of range (400)
             OperationalError: For network failures
         """
         url = f"{self._base_url}/{query_id}/rows"
         params = {
             "offset": offset,
-            "rowLimit": row_limit,
-            "omitSchema": "true" if omit_schema else "false",
+            "limit": row_limit,
+            "byteLimit": 20971520,  # 20MB default
         }
-
-        if self.workload:
-            params["workload"] = self.workload
 
         try:
             response = self._make_request("GET", url, params=params)
             return QueryResponse.from_dict(response.json())
         except Exception as e:
-            # Handle "Request out of range" gracefully
+            # Handle "Request out of range" gracefully (400 error)
             if "out of range" in str(e).lower():
                 # Return empty response
                 return QueryResponse(data=[], metadata=[], returned_rows=0)

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/client.py
@@ -16,7 +16,7 @@ import requests
 
 from ..exceptions import OperationalError, map_http_error_to_exception
 from ..types import infer_sql_parameter_type
-from .models import QueryResponse, QueryStatus, SqlParameter
+from .models import QueryResponse, QueryStatus
 
 
 class DataCloudQueryClient:
@@ -150,13 +150,15 @@ class DataCloudQueryClient:
 
     def _convert_parameters(self, params: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
-        Convert Python dict parameters to sqlParameters array format.
+        Convert Python dict parameters to v3 parameters array format.
+
+        V3 uses positional parameters (question-mark style), so only type and value are sent.
 
         Args:
-            params: Dictionary of named parameters
+            params: Dictionary of named parameters (names ignored in v3)
 
         Returns:
-            List of parameter dictionaries in API format
+            List of parameter dictionaries in v3 API format: [{"type": "varchar", "value": "..."}]
         """
         if not params:
             return []
@@ -164,9 +166,11 @@ class DataCloudQueryClient:
         sql_params = []
         for name, value in params.items():
             param_type = infer_sql_parameter_type(value)
-            sql_params.append(
-                SqlParameter(name=name, value=value, type=param_type).to_dict()
-            )
+            # V3 parameter format: {"type": "varchar", "value": "..."} (lowercase type)
+            sql_params.append({
+                "type": param_type.lower(),
+                "value": value,
+            })
 
         return sql_params
 
@@ -177,35 +181,44 @@ class DataCloudQueryClient:
         row_limit: int = 1000000,
     ) -> QueryResponse:
         """
-        Execute a SQL query (createSqlQuery endpoint).
+        Execute a SQL query via POST /api/v3/query.
 
         Args:
-            sql: SQL query string (may contain :param placeholders)
-            parameters: Named parameters dict (e.g., {"param": "value"})
-            row_limit: Maximum rows to return in initial response (server may limit)
+            sql: SQL query string
+            parameters: Named parameters dict (e.g., {"status": "Active"})
+            row_limit: Maximum rows to return (passed as queryRowLimit)
 
         Returns:
             QueryResponse with initial results and status
 
         Raises:
-            ProgrammingError: For SQL syntax errors
-            OperationalError: For auth/network failures
+            ProgrammingError: For SQL syntax errors (400)
+            OperationalError: For auth/network failures (401, 403, 500+)
         """
-        params = {}
-        if self.workload:
-            params["workload"] = self.workload
-
         request_body = {
             "sql": sql,
-            "rowLimit": row_limit,
+            "transferMode": "ADAPTIVE",
+            "queryRowLimit": row_limit,
         }
 
-        # Add parameters if provided
+        # Add parameters if provided (v3 uses positional parameters)
         if parameters:
-            request_body["sqlParameters"] = self._convert_parameters(parameters)
+            request_body["parameters"] = self._convert_parameters(parameters)
 
-        response = self._make_request("POST", self._base_url, params=params, json_data=request_body)
-        return QueryResponse.from_dict(response.json())
+        response = self._make_request("POST", self._base_url, json_data=request_body)
+
+        # Parse response body
+        body = response.json()
+        query_response = QueryResponse.from_dict(body)
+
+        # Parse status from x-hyperdb-status header (v3)
+        status_header = response.headers.get("x-hyperdb-status")
+        if status_header:
+            import json
+            status_data = json.loads(status_header)
+            query_response.status = QueryStatus.from_dict(status_data)
+
+        return query_response
 
     def get_query_status(
         self, query_id: str, wait_time_ms: Optional[int] = None

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
@@ -166,31 +166,3 @@ class QueryResponse:
             returned_rows=data.get("returnedRows", 0),
             status=status,
         )
-
-
-@dataclass
-class SqlParameter:
-    """
-    SQL parameter for parameterized queries.
-
-    Attributes:
-        name: Parameter name (without colon prefix)
-        value: Parameter value
-        type: Data Cloud type name
-    """
-    name: str
-    value: Any
-    type: str
-
-    def to_dict(self) -> dict:
-        """
-        Convert to API request dictionary format.
-
-        Returns:
-            Dictionary with name, value, and type
-        """
-        return {
-            "name": self.name,
-            "value": self.value,
-            "type": self.type,
-        }

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/api/models.py
@@ -34,14 +34,20 @@ class QueryStatus:
         Create QueryStatus from API response dictionary.
 
         Args:
-            data: Status dictionary from API response
+            data: Status dictionary from API response (v3: from x-hyperdb-status header)
 
         Returns:
             QueryStatus instance
         """
+        completion_status = data.get("completionStatus", "")
+
+        # Normalize v3 enum: RUNNING_OR_UNSPECIFIED → RUNNING
+        if completion_status.upper() == "RUNNING_OR_UNSPECIFIED":
+            completion_status = "RUNNING"
+
         return cls(
             query_id=data.get("queryId", ""),
-            completion_status=data.get("completionStatus", ""),
+            completion_status=completion_status,
             progress=data.get("progress", 0.0),
             row_count=data.get("rowCount", 0),
             chunk_count=data.get("chunkCount", 0),
@@ -132,18 +138,24 @@ class QueryResponse:
         Create QueryResponse from API response dictionary.
 
         Args:
-            data: Response dictionary from API
+            data: Response dictionary from API (v3: metadata.columns wrapper)
 
         Returns:
             QueryResponse instance
         """
-        # Parse metadata
-        metadata = [
-            ColumnMetadata.from_dict(col)
-            for col in data.get("metadata", [])
-        ]
+        # V3 wraps columns in metadata.columns, v2 had flat metadata array
+        metadata_raw = data.get("metadata", {})
+        if isinstance(metadata_raw, dict):
+            # V3 shape: {"metadata": {"columns": [...]}}
+            columns = metadata_raw.get("columns", [])
+        else:
+            # V2 shape: {"metadata": [...]}
+            columns = metadata_raw
 
-        # Parse status if present
+        # Parse metadata
+        metadata = [ColumnMetadata.from_dict(col) for col in columns]
+
+        # Parse status if present (not in fetch_results responses)
         status = None
         if "status" in data:
             status = QueryStatus.from_dict(data["status"])

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/__init__.py
@@ -1,6 +1,7 @@
 """Authentication module for Salesforce Data Cloud."""
 
 from .oauth import (
+    ClientCredentialsAuthenticator,
     JWTAuthenticator,
     OAuthAuthenticator,
     RefreshTokenAuthenticator,
@@ -13,5 +14,6 @@ __all__ = [
     "UsernamePasswordAuthenticator",
     "JWTAuthenticator",
     "RefreshTokenAuthenticator",
+    "ClientCredentialsAuthenticator",
     "DataCloudTokenExchanger",
 ]

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/__init__.py
@@ -1,1 +1,17 @@
-# Authentication module
+"""Authentication module for Salesforce Data Cloud."""
+
+from .oauth import (
+    JWTAuthenticator,
+    OAuthAuthenticator,
+    RefreshTokenAuthenticator,
+    UsernamePasswordAuthenticator,
+)
+from .token_exchanger import DataCloudTokenExchanger
+
+__all__ = [
+    "OAuthAuthenticator",
+    "UsernamePasswordAuthenticator",
+    "JWTAuthenticator",
+    "RefreshTokenAuthenticator",
+    "DataCloudTokenExchanger",
+]

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
@@ -329,3 +329,63 @@ class RefreshTokenAuthenticator(OAuthAuthenticator):
             raise OperationalError(
                 f"Authentication failed with refresh token: {e}"
             ) from e
+
+
+class ClientCredentialsAuthenticator(OAuthAuthenticator):
+    """
+    OAuth 2.0 Client Credentials flow.
+
+    This flow uses only client_id and client_secret to authenticate.
+    It's suitable for server-to-server integrations where no user context
+    is required (e.g., Data Cloud connectors with appropriate permissions).
+    """
+
+    def __init__(
+        self,
+        login_url: str = "https://login.salesforce.com",
+        client_id: str = None,
+        client_secret: str = None,
+    ):
+        """
+        Initialize client credentials authenticator.
+
+        Args:
+            login_url: Salesforce login URL (default: "https://login.salesforce.com")
+            client_id: Connected app client ID
+            client_secret: Connected app client secret
+        """
+        super().__init__(login_url)
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def _fetch_new_token(self) -> tuple[str, int, str]:
+        """Fetch OAuth token using client credentials flow."""
+        token_url = f"{self.login_url}/services/oauth2/token"
+
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        try:
+            response = requests.post(token_url, data=data, timeout=30)
+            response.raise_for_status()
+            token_data = response.json()
+
+            access_token = token_data.get("access_token")
+            expires_in = token_data.get("expires_in", 7200)
+            instance_url = token_data.get("instance_url")
+
+            if not access_token:
+                raise OperationalError("No access token in response")
+
+            if not instance_url:
+                raise OperationalError("No instance_url in response")
+
+            return access_token, expires_in, instance_url
+
+        except requests.exceptions.RequestException as e:
+            raise OperationalError(
+                f"Authentication failed with client credentials: {e}"
+            ) from e

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
@@ -6,7 +6,8 @@ This module provides OAuth authenticators for different flows:
 - JWT Bearer Token (OAuth 2.0 JWT Bearer Flow)
 - Refresh Token (OAuth 2.0 Refresh Token Flow)
 
-All authenticators implement token caching with automatic refresh.
+All authenticators fetch a fresh token on every call (no caching), matching
+the JDBC driver's DataCloudTokenProvider.
 """
 
 from __future__ import annotations
@@ -25,8 +26,8 @@ class OAuthAuthenticator(ABC):
     """
     Abstract base class for OAuth authenticators.
 
-    All authenticators must implement get_oauth_token() and handle token caching
-    with automatic refresh before expiration (60s buffer).
+    All authenticators must implement _fetch_new_token(). get_oauth_token()
+    always fetches a fresh token — no core-token caching (matches JDBC).
     """
 
     def __init__(self, login_url: str = "https://login.salesforce.com"):
@@ -38,8 +39,6 @@ class OAuthAuthenticator(ABC):
                       "https://test.salesforce.com" for sandboxes)
         """
         self.login_url = login_url.rstrip("/")
-        self._cached_token: Optional[str] = None
-        self._token_expiry: Optional[float] = None
         self._instance_url: Optional[str] = None
 
     @abstractmethod
@@ -57,9 +56,10 @@ class OAuthAuthenticator(ABC):
 
     def get_oauth_token(self) -> str:
         """
-        Get a valid OAuth token, using cache or fetching a new one if needed.
+        Fetch a fresh OAuth token.
 
-        Automatically refreshes the token if it's within 60 seconds of expiry.
+        Matches the JDBC driver's DataCloudTokenProvider.getOAuthToken(), which
+        always fetches a new core token rather than caching one.
 
         Returns:
             Valid OAuth access token
@@ -67,20 +67,7 @@ class OAuthAuthenticator(ABC):
         Raises:
             OperationalError: If authentication fails
         """
-        current_time = time.time()
-
-        # Check if we have a cached token that's still valid (with 60s buffer)
-        if (
-            self._cached_token is not None
-            and self._token_expiry is not None
-            and current_time < (self._token_expiry - 60)
-        ):
-            return self._cached_token
-
-        # Fetch new token and instance URL
-        access_token, expires_in, instance_url = self._fetch_new_token()
-        self._cached_token = access_token
-        self._token_expiry = current_time + expires_in
+        access_token, _expires_in, instance_url = self._fetch_new_token()
         self._instance_url = instance_url
 
         return access_token
@@ -105,11 +92,6 @@ class OAuthAuthenticator(ABC):
             raise OperationalError("Instance URL not available from OAuth response")
 
         return self._instance_url
-
-    def invalidate_token(self):
-        """Invalidate the cached token, forcing a refresh on next request."""
-        self._cached_token = None
-        self._token_expiry = None
 
 
 class UsernamePasswordAuthenticator(OAuthAuthenticator):

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
@@ -1,0 +1,200 @@
+"""
+Data Cloud token exchanger (core token → CDP token).
+
+Wraps any OAuthAuthenticator and exchanges Salesforce core tokens for
+Data Cloud (CDP) tokens via the /services/a360/token endpoint.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import requests
+
+from ..exceptions import OperationalError
+from .oauth import OAuthAuthenticator
+
+
+class DataCloudTokenExchanger:
+    """
+    Exchanges Salesforce core tokens for Data Cloud CDP tokens.
+
+    Wraps any OAuthAuthenticator instance and handles the token exchange flow:
+    1. Fetch core token from authenticator
+    2. POST to /services/a360/token with core token
+    3. Cache CDP token with 60s expiry buffer
+    4. Revoke core token for security
+
+    The CDP token exchange returns the Data Cloud tenant endpoint, which is
+    different from the Salesforce instance URL.
+    """
+
+    # Token exchange grant type (from v1 precedent)
+    CDP_GRANT_TYPE = "urn:salesforce:grant-type:external:cdp"
+    CDP_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+    def __init__(
+        self,
+        core_authenticator: OAuthAuthenticator,
+        dataspace: Optional[str] = None,
+    ):
+        """
+        Initialize the CDP token exchanger.
+
+        Args:
+            core_authenticator: An OAuthAuthenticator instance that provides core tokens
+            dataspace: Data space name to pass to the exchange endpoint (optional)
+
+        Note: Verify the constructor signature matches the contract: login_url (default "https://login.salesforce.com"),
+              client_id, client_secret. All instance attributes (self.client_id, self.client_secret) are set from
+              constructor parameters per OAuthAuthenticator pattern.
+        """
+        self._core_authenticator = core_authenticator
+        self._dataspace = dataspace
+        self._cached_cdp_token: Optional[str] = None
+        self._token_expiry: Optional[float] = None
+        self._tenant_endpoint: Optional[str] = None
+
+    def get_cdp_token(self) -> str:
+        """
+        Get a valid CDP token, using cache or exchanging a new one if needed.
+
+        Uses the same 60s-buffer caching pattern as OAuthAuthenticator:
+        - If cached token exists and current_time < (expiry - 60), return cached token
+        - Otherwise, fetch a fresh core token and exchange it for a CDP token
+
+        Returns:
+            Valid CDP access token
+
+        Raises:
+            OperationalError: If token exchange fails
+        """
+        current_time = time.time()
+
+        # Check cache with 60s buffer
+        if (
+            self._cached_cdp_token is not None
+            and self._token_expiry is not None
+            and current_time < (self._token_expiry - 60)
+        ):
+            return self._cached_cdp_token
+
+        # Exchange core token for CDP token
+        core_token = self._core_authenticator.get_oauth_token()
+        instance_url = self._core_authenticator.get_instance_url()
+
+        cdp_token, expires_in, tenant_endpoint = self._exchange_token(
+            instance_url, core_token
+        )
+
+        # Cache CDP token
+        self._cached_cdp_token = cdp_token
+        self._token_expiry = current_time + expires_in
+        self._tenant_endpoint = tenant_endpoint
+
+        # Revoke core token for security (match v1 behavior)
+        self._revoke_core_token(instance_url, core_token)
+
+        return cdp_token
+
+    def get_tenant_endpoint(self) -> str:
+        """
+        Get the Data Cloud tenant endpoint URL.
+
+        The tenant endpoint is returned by the CDP token exchange and is used
+        as the base URL for all off-core v3 API calls.
+
+        Returns:
+            Data Cloud tenant endpoint (e.g., "https://{tenant}.c360a.salesforce.com")
+
+        Raises:
+            OperationalError: If no token exchange has occurred yet
+        """
+        if self._tenant_endpoint is None:
+            # Trigger exchange to get tenant endpoint
+            self.get_cdp_token()
+
+        if self._tenant_endpoint is None:
+            raise OperationalError("Tenant endpoint not available from CDP token exchange")
+
+        return self._tenant_endpoint
+
+    def invalidate_token(self):
+        """
+        Invalidate the cached CDP token, forcing a re-exchange on next request.
+
+        Note: This does NOT invalidate the core authenticator's token.
+        """
+        self._cached_cdp_token = None
+        self._token_expiry = None
+
+    def _exchange_token(
+        self, instance_url: str, core_token: str
+    ) -> tuple[str, int, str]:
+        """
+        Exchange core token for CDP token via /services/a360/token.
+
+        Args:
+            instance_url: Salesforce instance URL (from core OAuth response)
+            core_token: Core access token
+
+        Returns:
+            Tuple of (cdp_token, expires_in_seconds, tenant_endpoint)
+
+        Raises:
+            OperationalError: If exchange fails
+        """
+        exchange_url = f"{instance_url}/services/a360/token"
+
+        params = {
+            "grant_type": self.CDP_GRANT_TYPE,
+            "subject_token_type": self.CDP_SUBJECT_TOKEN_TYPE,
+            "subject_token": core_token,
+        }
+
+        # Add dataspace if configured
+        if self._dataspace:
+            params["dataspace"] = self._dataspace
+
+        try:
+            response = requests.post(exchange_url, params=params, timeout=30)
+            response.raise_for_status()
+            token_data = response.json()
+
+            access_token = token_data.get("access_token")
+            expires_in = token_data.get("expires_in")
+            tenant_endpoint = token_data.get("instance_url")
+
+            if not access_token:
+                raise OperationalError("No access_token in CDP token exchange response")
+
+            if not expires_in:
+                raise OperationalError("No expires_in in CDP token exchange response")
+
+            if not tenant_endpoint:
+                raise OperationalError("No instance_url in CDP token exchange response")
+
+            return access_token, expires_in, tenant_endpoint
+
+        except requests.exceptions.RequestException as e:
+            raise OperationalError(f"CDP token exchange failed: {e}") from e
+
+    def _revoke_core_token(self, instance_url: str, core_token: str):
+        """
+        Revoke the core token after successful CDP token exchange.
+
+        This matches v1 behavior and improves security by limiting core token lifetime.
+
+        Args:
+            instance_url: Salesforce instance URL
+            core_token: Core access token to revoke
+        """
+        revoke_url = f"{instance_url}/services/oauth2/revoke"
+        params = {"token": core_token}
+
+        try:
+            requests.post(revoke_url, params=params, timeout=10)
+            # Revocation failures are non-fatal (token will expire naturally)
+        except requests.exceptions.RequestException:
+            pass  # Silently ignore revocation failures

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
@@ -45,10 +45,6 @@ class DataCloudTokenExchanger:
         Args:
             core_authenticator: An OAuthAuthenticator instance that provides core tokens
             dataspace: Data space name to pass to the exchange endpoint (optional)
-
-        Note: Verify the constructor signature matches the contract: login_url (default "https://login.salesforce.com"),
-              client_id, client_secret. All instance attributes (self.client_id, self.client_secret) are set from
-              constructor parameters per OAuthAuthenticator pattern.
         """
         self._core_authenticator = core_authenticator
         self._dataspace = dataspace

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
@@ -21,10 +21,10 @@ class DataCloudTokenExchanger:
     Exchanges Salesforce core tokens for Data Cloud CDP tokens.
 
     Wraps any OAuthAuthenticator instance and handles the token exchange flow:
-    1. Fetch core token from authenticator
+    1. Fetch a fresh core token from authenticator (no core-token caching)
     2. POST to /services/a360/token with core token
-    3. Cache CDP token with 60s expiry buffer
-    4. Revoke core token for security
+    3. Cache CDP token until it expires (no refresh buffer, matches JDBC's
+       DataCloudToken.isAlive())
 
     The CDP token exchange returns the Data Cloud tenant endpoint, which is
     different from the Salesforce instance URL.
@@ -56,9 +56,9 @@ class DataCloudTokenExchanger:
         """
         Get a valid CDP token, using cache or exchanging a new one if needed.
 
-        Uses the same 60s-buffer caching pattern as OAuthAuthenticator:
-        - If cached token exists and current_time < (expiry - 60), return cached token
-        - Otherwise, fetch a fresh core token and exchange it for a CDP token
+        Mirrors JDBC's DataCloudToken.isAlive(): the cached token is used while
+        current_time <= expiry, with no refresh buffer. On a miss, a fresh core
+        token is fetched (the core authenticator never caches) and exchanged.
 
         Returns:
             Valid CDP access token
@@ -68,15 +68,15 @@ class DataCloudTokenExchanger:
         """
         current_time = time.time()
 
-        # Check cache with 60s buffer
+        # Check cache — alive until exact expiry, no buffer.
         if (
             self._cached_cdp_token is not None
             and self._token_expiry is not None
-            and current_time < (self._token_expiry - 60)
+            and current_time <= self._token_expiry
         ):
             return self._cached_cdp_token
 
-        # Exchange core token for CDP token
+        # Exchange a fresh core token for a CDP token
         core_token = self._core_authenticator.get_oauth_token()
         instance_url = self._core_authenticator.get_instance_url()
 
@@ -88,9 +88,6 @@ class DataCloudTokenExchanger:
         self._cached_cdp_token = cdp_token
         self._token_expiry = current_time + expires_in
         self._tenant_endpoint = tenant_endpoint
-
-        # Revoke core token for security (match v1 behavior)
-        self._revoke_core_token(instance_url, core_token)
 
         return cdp_token
 
@@ -201,28 +198,3 @@ class DataCloudTokenExchanger:
         if endpoint.startswith(("https://", "http://")):
             return endpoint
         return f"https://{endpoint}"
-
-    def _revoke_core_token(self, instance_url: str, core_token: str):
-        """
-        Revoke the core token after successful CDP token exchange.
-
-        This matches v1 behavior and improves security by limiting core token lifetime.
-        Also invalidates the core authenticator's own cache: that cache's ~2h TTL
-        outlives the revoked token, so without this a later re-exchange (the CDP
-        token lives ~1h) would pull the same now-revoked token back out of cache
-        and fail the exchange with a 401.
-
-        Args:
-            instance_url: Salesforce instance URL
-            core_token: Core access token to revoke
-        """
-        revoke_url = f"{instance_url}/services/oauth2/revoke"
-        params = {"token": core_token}
-
-        try:
-            requests.post(revoke_url, params=params, timeout=10)
-            # Revocation failures are non-fatal (token will expire naturally)
-        except requests.exceptions.RequestException:
-            pass  # Silently ignore revocation failures
-        finally:
-            self._core_authenticator.invalidate_token()

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
@@ -207,6 +207,10 @@ class DataCloudTokenExchanger:
         Revoke the core token after successful CDP token exchange.
 
         This matches v1 behavior and improves security by limiting core token lifetime.
+        Also invalidates the core authenticator's own cache: that cache's ~2h TTL
+        outlives the revoked token, so without this a later re-exchange (the CDP
+        token lives ~1h) would pull the same now-revoked token back out of cache
+        and fail the exchange with a 401.
 
         Args:
             instance_url: Salesforce instance URL
@@ -220,3 +224,5 @@ class DataCloudTokenExchanger:
             # Revocation failures are non-fatal (token will expire naturally)
         except requests.exceptions.RequestException:
             pass  # Silently ignore revocation failures
+        finally:
+            self._core_authenticator.invalidate_token()

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
@@ -171,10 +171,36 @@ class DataCloudTokenExchanger:
             if not tenant_endpoint:
                 raise OperationalError("No instance_url in CDP token exchange response")
 
+            # The a360 exchange returns the tenant endpoint as a bare host
+            # (no scheme). On-core v1 prepends https:// at request time; we
+            # normalize once here so the off-core client can build valid URLs.
+            tenant_endpoint = self._normalize_endpoint(tenant_endpoint)
+
             return access_token, expires_in, tenant_endpoint
 
         except requests.exceptions.RequestException as e:
             raise OperationalError(f"CDP token exchange failed: {e}") from e
+
+    @staticmethod
+    def _normalize_endpoint(endpoint: str) -> str:
+        """
+        Ensure the tenant endpoint carries an explicit scheme.
+
+        The /services/a360/token response returns instance_url as a bare host
+        (e.g. "tenant.c360a.salesforce.com"). The off-core query client builds
+        request URLs by string concatenation, so a missing scheme makes requests
+        raise "No scheme supplied". Prepend https:// when absent; leave an
+        existing http:// or https:// untouched (idempotent).
+
+        Args:
+            endpoint: Tenant endpoint as returned by the exchange (with or without scheme)
+
+        Returns:
+            Endpoint guaranteed to start with a scheme
+        """
+        if endpoint.startswith(("https://", "http://")):
+            return endpoint
+        return f"https://{endpoint}"
 
     def _revoke_core_token(self, instance_url: str, core_token: str):
         """

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/connection.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/connection.py
@@ -7,7 +7,6 @@ The Connection class manages the database connection and creates cursors.
 from typing import List, Optional
 
 from .api.client import DataCloudQueryClient
-from .auth.oauth import OAuthAuthenticator
 from .cursor import Cursor
 from .exceptions import InterfaceError
 from .metadata import DataCloudTable
@@ -23,7 +22,7 @@ class Connection:
 
     def __init__(
         self,
-        authenticator: OAuthAuthenticator,
+        token_provider,  # Type: DataCloudTokenExchanger (import avoided for circular dep)
         dataspace: Optional[str] = None,
         workload: Optional[str] = None,
     ):
@@ -31,22 +30,21 @@ class Connection:
         Initialize connection.
 
         Args:
-            authenticator: OAuth authenticator instance
+            token_provider: DataCloudTokenExchanger instance (wraps core authenticator)
             dataspace: Data space name (default: "default")
             workload: Optional workload name for logging/debugging
 
         Note: Use the connect() factory function instead of instantiating directly.
         """
-        self._authenticator = authenticator
+        self._token_provider = token_provider
         self._dataspace = dataspace
         self._workload = workload
         self._closed = False
 
-        # Create API client
-        # Note: instance_url is obtained from OAuth response, not user input
+        # Create API client with v3 parameters
         self._client = DataCloudQueryClient(
-            tenant_endpoint=authenticator.get_instance_url(),
-            auth_token_getter=authenticator.get_oauth_token,
+            tenant_endpoint=token_provider.get_tenant_endpoint(),
+            auth_token_getter=token_provider.get_cdp_token,
             dataspace=dataspace,
             workload=workload,
         )

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/connection.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/connection.py
@@ -45,7 +45,7 @@ class Connection:
         # Create API client
         # Note: instance_url is obtained from OAuth response, not user input
         self._client = DataCloudQueryClient(
-            instance_url=authenticator.get_instance_url(),
+            tenant_endpoint=authenticator.get_instance_url(),
             auth_token_getter=authenticator.get_oauth_token,
             dataspace=dataspace,
             workload=workload,

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
@@ -143,7 +143,9 @@ class Cursor:
         Execute a SQL query.
 
         Args:
-            operation: SQL query string (may contain :param placeholders)
+            operation: SQL query string. May contain :name placeholders
+                (paramstyle="named"); these are rewritten to v3 positional
+                parameters before the request is sent.
             parameters: Named parameters dict (e.g., {"param": "value"})
 
         Returns:

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
@@ -7,7 +7,7 @@ The Cursor class executes queries and manages result retrieval.
 from typing import Any, Dict, List, Optional, Tuple
 
 from .api.client import DataCloudQueryClient
-from .api.models import ColumnMetadata
+from .api.models import ColumnMetadata, QueryStatus
 from .exceptions import InterfaceError, NotSupportedError
 from .types import build_description_tuple, convert_datacloud_value
 
@@ -40,6 +40,10 @@ class Cursor:
         self._description: Optional[List[Tuple]] = None
         self._rowcount: int = -1  # DB-API 2.0: -1 for SELECT, else number of rows affected
         self._closed: bool = False
+        # Latest QueryStatus observed on this cursor — refreshed by execute()
+        # and by the polling loop. Returned by get_query_status() without an
+        # extra HTTP call.
+        self._query_status: Optional[QueryStatus] = None
 
     @property
     def description(self) -> Optional[List[Tuple]]:
@@ -175,6 +179,7 @@ class Cursor:
         self._query_id = response.status.query_id
         self._metadata = response.metadata
         self._total_row_count = response.status.row_count
+        self._query_status = response.status
         self._rowcount = -1  # SELECT queries return -1
         self._build_description()
 
@@ -188,6 +193,7 @@ class Cursor:
             # Asynchronous response - need to poll until complete
             final_status = self._client.poll_until_complete(self._query_id)
             self._total_row_count = final_status.row_count
+            self._query_status = final_status
 
             # Fetch first chunk
             self._fetch_next_chunk()
@@ -324,6 +330,30 @@ class Cursor:
         self._check_query_executed()
 
         self._client.cancel_query(self._query_id)
+
+    def get_query_status(self) -> Optional[QueryStatus]:
+        """
+        Return the most recently observed QueryStatus for this cursor's query.
+
+        Non-blocking — does not issue an extra HTTP call. The status is
+        refreshed when `execute()` runs and after the async polling loop
+        completes. In off-core Query v3 the status is parsed from the
+        `x-hyperdb-status` response header and exposes: ``query_id``,
+        ``completion_status``, ``progress``, ``row_count``, ``chunk_count``,
+        ``expiration_time``.
+
+        Returns:
+            The latest QueryStatus, or None if no query has been executed.
+
+        Example:
+            cursor.execute("SELECT ...")
+            for _ in cursor:
+                pass
+            status = cursor.get_query_status()
+            print(status.row_count, status.progress)
+        """
+        self._check_closed()
+        return self._query_status
 
     def fetch_df(self):
         """

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/types.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/types.py
@@ -58,6 +58,13 @@ DATACLOUD_TYPE_TO_DBAPI = {
 }
 
 
+# Case-insensitive index derived from the canonical map above. The off-core Query v3
+# API returns lowercase type names (e.g. "varchar", "timestamptz"), while the Postgres
+# metadata catalog (_metadata_pg.py) emits the canonical capitalized names. Normalizing
+# the lookup key lets both resolve to the same DB-API type object.
+_DATACLOUD_TYPE_TO_DBAPI_LOWER = {key.lower(): value for key, value in DATACLOUD_TYPE_TO_DBAPI.items()}
+
+
 def convert_datacloud_value(value: Any, datacloud_type: str,
                            precision: Optional[int] = None,
                            scale: Optional[int] = None) -> Any:
@@ -80,13 +87,17 @@ def convert_datacloud_value(value: Any, datacloud_type: str,
     if value is None:
         return None
 
+    # v3 returns lowercase type names; the PG catalog emits capitalized ones.
+    # Normalize so both resolve. `or ""` guards against a missing/None type.
+    normalized_type = (datacloud_type or "").lower()
+
     try:
         # Varchar → str
-        if datacloud_type == "Varchar":
+        if normalized_type == "varchar":
             return str(value)
 
         # Numeric → Decimal/int/float
-        elif datacloud_type == "Numeric":
+        elif normalized_type == "numeric":
             # If scale is 0, return as int
             if scale == 0:
                 return int(value)
@@ -98,22 +109,22 @@ def convert_datacloud_value(value: Any, datacloud_type: str,
                 return Decimal(str(value))
 
         # Integer types → int
-        elif datacloud_type in ("Integer", "BigInt"):
+        elif normalized_type in ("integer", "bigint"):
             return int(value)
 
         # Float types → float
-        elif datacloud_type in ("Float", "Double"):
+        elif normalized_type in ("float", "double"):
             return float(value)
 
         # TimestampTZ → datetime with timezone
-        elif datacloud_type == "TimestampTZ":
+        elif normalized_type == "timestamptz":
             if isinstance(value, datetime):
                 return value
             # Parse string timestamp
             return dateutil_parser.parse(value)
 
         # Date → date
-        elif datacloud_type == "Date":
+        elif normalized_type == "date":
             if isinstance(value, date):
                 return value
             # Parse string date
@@ -121,7 +132,7 @@ def convert_datacloud_value(value: Any, datacloud_type: str,
             return dt.date()
 
         # Boolean → bool
-        elif datacloud_type == "Boolean":
+        elif normalized_type == "boolean":
             if isinstance(value, bool):
                 return value
             # Handle string representations
@@ -130,7 +141,7 @@ def convert_datacloud_value(value: Any, datacloud_type: str,
             return bool(value)
 
         # Text → str
-        elif datacloud_type == "Text":
+        elif normalized_type == "text":
             return str(value)
 
         # Unknown type - return as-is
@@ -195,8 +206,8 @@ def build_description_tuple(column_metadata: dict) -> tuple:
     precision = column_metadata.get("precision")
     scale = column_metadata.get("scale")
 
-    # Get DB-API type code
-    type_code = DATACLOUD_TYPE_TO_DBAPI.get(datacloud_type, STRING)
+    # Get DB-API type code (case-insensitive: v3 lowercase + PG-catalog capitalized)
+    type_code = _DATACLOUD_TYPE_TO_DBAPI_LOWER.get((datacloud_type or "").lower(), STRING)
 
     # display_size and internal_size are often None in DB-API implementations
     display_size = None

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -8,6 +8,7 @@ import pytest
 import responses
 
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
+from salesforce_datacloud_connector.api.models import QueryStatus
 from salesforce_datacloud_connector.exceptions import OperationalError, ProgrammingError
 
 
@@ -719,3 +720,49 @@ def test_execute_query_missing_status_header_raises_operational_error():
 
     with pytest.raises(OperationalError, match="x-hyperdb-status"):
         client.execute_query("SELECT name FROM users")
+
+
+def test_query_status_from_dict_real_payload():
+    """Verbatim shape v3 emits in the x-hyperdb-status response header."""
+    status = QueryStatus.from_dict(
+        {
+            "queryId": "q1",
+            "completionStatus": "Finished",
+            "progress": 1.0,
+            "rowCount": 1288,
+            "chunkCount": 1,
+            "expirationTime": "2025-09-26T10:55:07.438Z",
+        }
+    )
+
+    assert status.query_id == "q1"
+    assert status.is_complete()
+    assert status.row_count == 1288
+    assert status.chunk_count == 1
+    assert status.progress == 1.0
+    assert status.expiration_time == "2025-09-26T10:55:07.438Z"
+
+
+def test_query_status_from_empty_dict_does_not_throw():
+    status = QueryStatus.from_dict({})
+    assert status.query_id == ""
+    assert status.completion_status == ""
+    assert status.progress == 0.0
+    assert status.row_count == 0
+    assert status.chunk_count == 0
+    assert status.expiration_time is None
+
+
+def test_query_status_unknown_keys_ignored():
+    """Forward-compat: extra fields the server may add later must not raise."""
+    status = QueryStatus.from_dict(
+        {
+            "queryId": "q1",
+            "completionStatus": "Finished",
+            "progress": 1.0,
+            "rowCount": 0,
+            "chunkCount": 0,
+            "newServerSideField": {"foo": "bar"},
+        }
+    )
+    assert status.is_complete()

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -159,25 +159,32 @@ def test_execute_query_with_parameters_v3():
 
 
 @responses.activate
-def test_get_query_status():
-    """Test getting query status."""
+def test_get_query_status_v3():
+    """Test getting query status (v3 API)."""
+    status_header = {
+        "queryId": "query123",
+        "completionStatus": "FINISHED",
+        "progress": 1.0,
+        "rowCount": 1000,
+        "chunkCount": 1,
+    }
+
     responses.add(
         responses.GET,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql/query123",
+        "https://test.c360a.salesforce.com/api/v3/query/query123",
         json={
-            "status": {
-                "queryId": "query123",
-                "completionStatus": "Finished",
-                "progress": 1.0,
-                "rowCount": 1000,
-                "chunkCount": 1,
-            }
+            "metadata": {"columns": []},
+            "data": None,
+            "returnedRows": 0
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -196,6 +196,55 @@ def test_get_query_status_v3():
 
 
 @responses.activate
+def test_fetch_results_v3():
+    """Test fetching query results (v3 API)."""
+    def check_request(request):
+        # Verify v3 query parameters
+        assert "offset=0" in request.url
+        assert "limit=1000000" in request.url
+        assert "byteLimit=20971520" in request.url
+        # v3 should not have rowLimit or omitSchema params
+        assert "rowLimit" not in request.url
+        assert "omitSchema" not in request.url
+        # v3 should not have workload param in query string
+        assert "workload=" not in request.url
+
+        return (200, {}, json.dumps({
+            "metadata": {
+                "columns": [
+                    {"name": "id", "type": "numeric", "nullable": False},
+                    {"name": "value", "type": "varchar", "nullable": True}
+                ]
+            },
+            "data": [[1, "first"], [2, "second"]],
+            "returnedRows": 2
+        }))
+
+    responses.add_callback(
+        responses.GET,
+        "https://test.c360a.salesforce.com/api/v3/query/query123/rows",
+        callback=check_request,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+
+    response = client.fetch_results(
+        query_id="query123",
+        offset=0,
+        row_limit=1000000,
+        omit_schema=False
+    )
+
+    assert len(response.data) == 2
+    assert response.data[0] == [1, "first"]
+    assert response.returned_rows == 2
+    assert len(response.metadata) == 2
+
+
+@responses.activate
 def test_get_query_status_with_long_polling():
     """Test query status with long-polling."""
     def check_request(request):

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -293,6 +293,62 @@ def test_error_response_v3():
 
 
 @responses.activate
+def test_poll_until_complete_v3():
+    """Test polling until query completes (v3 API)."""
+    # First poll: still running
+    responses.add(
+        responses.GET,
+        "https://test.c360a.salesforce.com/api/v3/query/query123",
+        json={
+            "metadata": {"columns": []},
+            "data": None,
+            "returnedRows": 0
+        },
+        headers={
+            "x-hyperdb-status": json.dumps({
+                "queryId": "query123",
+                "completionStatus": "RUNNING_OR_UNSPECIFIED",
+                "progress": 0.5,
+                "rowCount": 0,
+                "chunkCount": 0,
+            })
+        },
+        status=200,
+    )
+
+    # Second poll: completed
+    responses.add(
+        responses.GET,
+        "https://test.c360a.salesforce.com/api/v3/query/query123",
+        json={
+            "metadata": {"columns": []},
+            "data": None,
+            "returnedRows": 0
+        },
+        headers={
+            "x-hyperdb-status": json.dumps({
+                "queryId": "query123",
+                "completionStatus": "FINISHED",
+                "progress": 1.0,
+                "rowCount": 100,
+                "chunkCount": 1,
+            })
+        },
+        status=200,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+
+    status = client.poll_until_complete("query123", poll_interval_ms=100, timeout_seconds=10)
+
+    assert status.is_complete()
+    assert status.row_count == 100
+
+
+@responses.activate
 def test_get_query_status_with_long_polling():
     """Test query status with long-polling."""
     def check_request(request):

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -2,6 +2,8 @@
 Tests for Data Cloud Query API client.
 """
 
+import json
+
 import pytest
 import responses
 
@@ -15,31 +17,42 @@ def mock_token_getter():
 
 
 @responses.activate
-def test_execute_query_sync():
-    """Test executing a query that returns synchronous results."""
+def test_execute_query_sync_v3():
+    """Test executing a query that returns synchronous results (v3 API)."""
+    status_header = {
+        "queryId": "MTAuMjQuMTIzLjE5NDo3NDg0_cb6991ab",
+        "completionStatus": "RESULTS_PRODUCED",
+        "chunkCount": 1,
+        "rowCount": 2,
+        "progress": 1.0,
+        "expirationTime": "2025-09-26T10:55:07.438Z",
+        "executionStats": {
+            "wallClockTime": 1.122854338,
+            "rowsProcessed": 2
+        }
+    }
+
     responses.add(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         json={
-            "data": [["Alice", 30], ["Bob", 25]],
-            "metadata": [
-                {"name": "name", "type": "Varchar", "nullable": True},
-                {"name": "age", "type": "Numeric", "nullable": False, "precision": 10, "scale": 0},
-            ],
-            "returnedRows": 2,
-            "status": {
-                "queryId": "query123",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 2,
-                "chunkCount": 1,
+            "metadata": {
+                "columns": [
+                    {"name": "name", "type": "varchar", "nullable": True},
+                    {"name": "age", "type": "numeric", "nullable": False, "precision": 10, "scale": 0},
+                ]
             },
+            "data": [["Alice", 30], ["Bob", 25]],
+            "returnedRows": 2
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
@@ -48,35 +61,41 @@ def test_execute_query_sync():
     assert len(response.data) == 2
     assert response.data[0] == ["Alice", 30]
     assert response.returned_rows == 2
-    assert response.status.query_id == "query123"
+    assert response.status.query_id == "MTAuMjQuMTIzLjE5NDo3NDg0_cb6991ab"
     assert response.status.is_complete()
 
 
 @responses.activate
-def test_execute_query_async():
-    """Test executing a query that returns async status."""
+def test_execute_query_async_v3():
+    """Test executing a query that returns async status (v3 API)."""
+    status_header = {
+        "queryId": "MTAuMjQuMTIzLjE5NDo3NDg0_cb6991ab-async",
+        "completionStatus": "RUNNING_OR_UNSPECIFIED",
+        "chunkCount": 0,
+        "rowCount": 0,
+        "progress": 0.5,
+    }
+
     responses.add(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         json={
-            "data": [],
-            "metadata": [
-                {"name": "name", "type": "Varchar", "nullable": True},
-            ],
-            "returnedRows": 0,
-            "status": {
-                "queryId": "query456",
-                "completionStatus": "Running",
-                "progress": 0.5,
-                "rowCount": 0,
-                "chunkCount": 0,
+            "metadata": {
+                "columns": [
+                    {"name": "name", "type": "varchar", "nullable": True},
+                ]
             },
+            "data": None,
+            "returnedRows": 0
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
@@ -84,33 +103,55 @@ def test_execute_query_async():
 
     assert response.status.is_running()
     assert not response.status.is_complete()
-    assert response.status.query_id == "query456"
+    assert response.status.query_id == "MTAuMjQuMTIzLjE5NDo3NDg0_cb6991ab-async"
+    assert response.status.completion_status == "RUNNING"  # normalized
+    assert response.data is None or response.data == []
 
 
 @responses.activate
-def test_execute_query_with_parameters():
-    """Test executing a parameterized query."""
+def test_execute_query_with_parameters_v3():
+    """Test executing a parameterized query (v3 API)."""
     def check_request(request):
-        body = request.body.decode("utf-8")
-        assert "sqlParameters" in body
-        assert '"name": "status"' in body
-        assert '"value": "Active"' in body
-        assert '"type": "Varchar"' in body
-        return (200, {}, '{"data": [], "metadata": [], "returnedRows": 0, "status": {"queryId": "q1", "completionStatus": "ResultsProduced", "progress": 1.0, "rowCount": 0, "chunkCount": 0}}')
+        import json
+        body = json.loads(request.body.decode("utf-8"))
+        assert "parameters" in body
+        assert len(body["parameters"]) == 1
+        assert body["parameters"][0]["type"] == "varchar"
+        assert body["parameters"][0]["value"] == "Active"
+        # V3 does not include parameter names
+        assert "name" not in body["parameters"][0]
+
+        status_header = {
+            "queryId": "q1",
+            "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0,
+            "rowCount": 0,
+            "chunkCount": 0
+        }
+
+        return (
+            200,
+            {"x-hyperdb-status": json.dumps(status_header)},
+            json.dumps({
+                "metadata": {"columns": []},
+                "data": [],
+                "returnedRows": 0
+            })
+        )
 
     responses.add_callback(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         callback=check_request,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
     response = client.execute_query(
-        "SELECT * FROM users WHERE status = :status",
+        "SELECT * FROM users WHERE status = ?",
         parameters={"status": "Active"}
     )
 

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -297,16 +297,23 @@ def test_get_query_status_with_long_polling():
     """Test query status with long-polling."""
     def check_request(request):
         assert "waitTimeMs" in request.url
-        return (200, {}, '{"status": {"queryId": "q1", "completionStatus": "Running", "progress": 0.8, "rowCount": 0, "chunkCount": 0}}')
+        status_header = {
+            "queryId": "q1",
+            "completionStatus": "RUNNING_OR_UNSPECIFIED",
+            "progress": 0.8,
+            "rowCount": 0,
+            "chunkCount": 0
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)}, '{"metadata":{"columns":[]},"data":null,"returnedRows":0}')
 
     responses.add_callback(
         responses.GET,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql/q1",
+        "https://test.c360a.salesforce.com/api/v3/query/q1",
         callback=check_request,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
@@ -315,46 +322,24 @@ def test_get_query_status_with_long_polling():
 
 
 @responses.activate
-def test_fetch_results():
-    """Test fetching query results."""
-    responses.add(
-        responses.GET,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql/query123/rows",
-        json={
-            "data": [["row1"], ["row2"]],
-            "returnedRows": 2,
-        },
-        status=200,
-    )
-
-    client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
-        auth_token_getter=mock_token_getter,
-    )
-
-    response = client.fetch_results("query123", offset=0, row_limit=100)
-
-    assert len(response.data) == 2
-    assert response.returned_rows == 2
-
-
-@responses.activate
 def test_fetch_results_with_offset():
     """Test fetching results with pagination offset."""
     def check_request(request):
         assert "offset=100" in request.url
-        assert "rowLimit=50" in request.url
-        assert "omitSchema=true" in request.url
+        assert "limit=50" in request.url
+        assert "byteLimit=20971520" in request.url
+        assert "rowLimit" not in request.url
+        assert "omitSchema" not in request.url
         return (200, {}, '{"data": [["row101"]], "returnedRows": 1}')
 
     responses.add_callback(
         responses.GET,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql/query123/rows",
+        "https://test.c360a.salesforce.com/api/v3/query/query123/rows",
         callback=check_request,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
@@ -363,59 +348,44 @@ def test_fetch_results_with_offset():
 
 
 @responses.activate
-def test_cancel_query():
-    """Test canceling a query."""
-    responses.add(
-        responses.DELETE,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql/query123",
-        status=204,
-    )
-
-    client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
-        auth_token_getter=mock_token_getter,
-    )
-
-    # Should not raise
-    client.cancel_query("query123")
-
-
-@responses.activate
 def test_retry_on_500():
     """Test automatic retry on 500 errors."""
     # First two calls fail with 500, third succeeds
     responses.add(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         json={"error": "Internal Server Error"},
         status=500,
     )
     responses.add(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         json={"error": "Internal Server Error"},
         status=500,
     )
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 0,
+        "chunkCount": 0,
+    }
     responses.add(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         json={
+            "metadata": {"columns": []},
             "data": [],
-            "metadata": [],
             "returnedRows": 0,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 0,
-                "chunkCount": 0,
-            },
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
@@ -430,13 +400,13 @@ def test_no_retry_on_400():
     """Test that 400 errors are not retried."""
     responses.add(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         json={"message": "SQL syntax error"},
         status=400,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 
@@ -451,17 +421,25 @@ def test_no_retry_on_400():
 def test_workload_parameter():
     """Test that workload parameter is included in requests."""
     def check_request(request):
-        assert "workload=my_app" in request.url
-        return (200, {}, '{"data": [], "metadata": [], "returnedRows": 0, "status": {"queryId": "q1", "completionStatus": "ResultsProduced", "progress": 1.0, "rowCount": 0, "chunkCount": 0}}')
+        assert request.headers.get("x-hyperdb-workload") == "python-connector-v2_my_app"
+        assert "workload=" not in request.url
+        status_header = {
+            "queryId": "q1",
+            "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0,
+            "rowCount": 0,
+            "chunkCount": 0
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)}, '{"metadata":{"columns":[]},"data":[],"returnedRows":0}')
 
     responses.add_callback(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         callback=check_request,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
         workload="my_app",
     )
@@ -473,18 +451,25 @@ def test_workload_parameter():
 def test_dataspace_header():
     """Test that dataspace is included as a request header."""
     def check_request(request):
-        assert request.headers.get("dataspace") == "custom_space"
+        assert request.headers.get("ctx-dataspace-ds_name") == "custom_space"
         assert "dataspace" not in request.url
-        return (200, {}, '{"data": [], "metadata": [], "returnedRows": 0, "status": {"queryId": "q1", "completionStatus": "ResultsProduced", "progress": 1.0, "rowCount": 0, "chunkCount": 0}}')
+        status_header = {
+            "queryId": "q1",
+            "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0,
+            "rowCount": 0,
+            "chunkCount": 0
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)}, '{"metadata":{"columns":[]},"data":[],"returnedRows":0}')
 
     responses.add_callback(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         callback=check_request,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
         dataspace="custom_space",
     )
@@ -498,16 +483,23 @@ def test_auth_token_included():
     def check_request(request):
         assert "Authorization" in request.headers
         assert request.headers["Authorization"] == "Bearer mock_token_12345"
-        return (200, {}, '{"data": [], "metadata": [], "returnedRows": 0, "status": {"queryId": "q1", "completionStatus": "ResultsProduced", "progress": 1.0, "rowCount": 0, "chunkCount": 0}}')
+        status_header = {
+            "queryId": "q1",
+            "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0,
+            "rowCount": 0,
+            "chunkCount": 0
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)}, '{"metadata":{"columns":[]},"data":[],"returnedRows":0}')
 
     responses.add_callback(
         responses.POST,
-        "https://test.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://test.c360a.salesforce.com/api/v3/query",
         callback=check_request,
     )
 
     client = DataCloudQueryClient(
-        instance_url="https://test.salesforce.com",
+        tenant_endpoint="https://test.c360a.salesforce.com",
         auth_token_getter=mock_token_getter,
     )
 

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -263,6 +263,36 @@ def test_cancel_query_v3():
 
 
 @responses.activate
+def test_error_response_v3():
+    """Test v3 error response mapping."""
+    responses.add(
+        responses.POST,
+        "https://test.c360a.salesforce.com/api/v3/query",
+        json={
+            "timestamp": "2026-07-22T10:55:07.000+00:00",
+            "error": "COMMON_ERROR_GENERIC",
+            "message": "SQL syntax error: unexpected token",
+            "path": "/api/v3/query",
+            "tenantId": "tenant123",
+            "internalErrorCode": "COMMON_ERROR_GENERIC",
+            "details": {}
+        },
+        status=400,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+
+    with pytest.raises(ProgrammingError) as exc_info:
+        client.execute_query("SELECT * FROM invalid syntax")
+
+    assert "SQL syntax error" in str(exc_info.value)
+    assert exc_info.value.http_status == 400
+
+
+@responses.activate
 def test_get_query_status_with_long_polling():
     """Test query status with long-polling."""
     def check_request(request):

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -245,6 +245,24 @@ def test_fetch_results_v3():
 
 
 @responses.activate
+def test_cancel_query_v3():
+    """Test cancelling a running query (v3 API)."""
+    responses.add(
+        responses.DELETE,
+        "https://test.c360a.salesforce.com/api/v3/query/query123",
+        status=204,  # v3 returns 204 No Content on success
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+
+    # Should not raise any exception
+    client.cancel_query("query123")
+
+
+@responses.activate
 def test_get_query_status_with_long_polling():
     """Test query status with long-polling."""
     def check_request(request):

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -8,7 +8,7 @@ import pytest
 import responses
 
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
-from salesforce_datacloud_connector.exceptions import ProgrammingError
+from salesforce_datacloud_connector.exceptions import OperationalError, ProgrammingError
 
 
 def mock_token_getter():
@@ -560,3 +560,29 @@ def test_auth_token_included():
     )
 
     client.execute_query("SELECT 1")
+
+
+@responses.activate
+def test_execute_query_missing_status_header_raises_operational_error():
+    """A 200 response with no x-hyperdb-status header must raise a clear
+    OperationalError, not a downstream AttributeError (status lives only in
+    the header in v3)."""
+    responses.add(
+        responses.POST,
+        "https://test.c360a.salesforce.com/api/v3/query",
+        json={
+            "metadata": {"columns": [{"name": "name", "type": "varchar", "nullable": True}]},
+            "data": [["Alice"]],
+            "returnedRows": 1,
+        },
+        # NOTE: deliberately no x-hyperdb-status header
+        status=200,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+
+    with pytest.raises(OperationalError, match="x-hyperdb-status"):
+        client.execute_query("SELECT name FROM users")

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -159,6 +159,139 @@ def test_execute_query_with_parameters_v3():
 
 
 @responses.activate
+def test_named_parameters_translated_to_qmark_v3():
+    """The driver advertises paramstyle='named', but v3 accepts only positional
+    (qmark) parameters. A :name placeholder in the SQL must be rewritten to ?
+    and its value emitted positionally, or the server rejects the query with
+    "conflicting parameter style 'named' ... set to 'qmark'"."""
+    def check_request(request):
+        body = json.loads(request.body.decode("utf-8"))
+        assert body["sql"] == "SELECT ? AS msg"
+        assert body["parameters"] == [{"type": "varchar", "value": "hi there"}]
+
+        status_header = {
+            "queryId": "q1", "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0, "rowCount": 0, "chunkCount": 0,
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)},
+                json.dumps({"metadata": {"columns": []}, "data": [], "returnedRows": 0}))
+
+    responses.add_callback(
+        responses.POST,
+        "https://test.c360a.salesforce.com/api/v3/query",
+        callback=check_request,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+    client.execute_query("SELECT :greeting AS msg", parameters={"greeting": "hi there"})
+
+
+@responses.activate
+def test_named_parameter_reuse_translated_positionally_v3():
+    """A named parameter used more than once expands to one positional ? per
+    occurrence, with the value repeated in the parameters array."""
+    def check_request(request):
+        body = json.loads(request.body.decode("utf-8"))
+        assert body["sql"] == "SELECT ? AS a, ? + 1 AS b"
+        assert body["parameters"] == [
+            {"type": "numeric", "value": 7},
+            {"type": "numeric", "value": 7},
+        ]
+
+        status_header = {
+            "queryId": "q1", "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0, "rowCount": 0, "chunkCount": 0,
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)},
+                json.dumps({"metadata": {"columns": []}, "data": [], "returnedRows": 0}))
+
+    responses.add_callback(
+        responses.POST,
+        "https://test.c360a.salesforce.com/api/v3/query",
+        callback=check_request,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+    client.execute_query("SELECT :n AS a, :n + 1 AS b", parameters={"n": 7})
+
+
+@responses.activate
+def test_qmark_sql_passes_through_unchanged_v3():
+    """SQL that already uses positional ? placeholders (e.g. internal catalog
+    queries) has no :name tokens: the SQL is left untouched and the parameter
+    array is built from the dict's insertion order."""
+    def check_request(request):
+        body = json.loads(request.body.decode("utf-8"))
+        assert body["sql"] == "SELECT * FROM t WHERE a = ? AND b = ?"
+        assert body["parameters"] == [
+            {"type": "varchar", "value": "x"},
+            {"type": "varchar", "value": "y"},
+        ]
+
+        status_header = {
+            "queryId": "q1", "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0, "rowCount": 0, "chunkCount": 0,
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)},
+                json.dumps({"metadata": {"columns": []}, "data": [], "returnedRows": 0}))
+
+    responses.add_callback(
+        responses.POST,
+        "https://test.c360a.salesforce.com/api/v3/query",
+        callback=check_request,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+    # dict order (a then b) defines positional order for qmark SQL
+    client.execute_query(
+        "SELECT * FROM t WHERE a = ? AND b = ?",
+        parameters={"a": "x", "b": "y"},
+    )
+
+
+@responses.activate
+def test_named_translation_leaves_type_casts_alone_v3():
+    """Postgres :: type casts must not be mistaken for :name placeholders when
+    translating. Only the genuine :name (present in params) is rewritten."""
+    def check_request(request):
+        body = json.loads(request.body.decode("utf-8"))
+        # ::regclass cast preserved; :kind rewritten to ?
+        assert body["sql"] == "SELECT 'x'::regclass WHERE relkind = ?"
+        assert body["parameters"] == [{"type": "varchar", "value": "r"}]
+
+        status_header = {
+            "queryId": "q1", "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0, "rowCount": 0, "chunkCount": 0,
+        }
+        return (200, {"x-hyperdb-status": json.dumps(status_header)},
+                json.dumps({"metadata": {"columns": []}, "data": [], "returnedRows": 0}))
+
+    responses.add_callback(
+        responses.POST,
+        "https://test.c360a.salesforce.com/api/v3/query",
+        callback=check_request,
+    )
+
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+    client.execute_query(
+        "SELECT 'x'::regclass WHERE relkind = :kind",
+        parameters={"kind": "r"},
+    )
+
+
+@responses.activate
 def test_get_query_status_v3():
     """Test getting query status (v3 API)."""
     status_header = {

--- a/salesforce_datacloud_connector/tests/test_auth.py
+++ b/salesforce_datacloud_connector/tests/test_auth.py
@@ -312,3 +312,59 @@ def test_missing_instance_url_in_response():
 
     with pytest.raises(OperationalError, match="No instance_url in response"):
         auth.get_oauth_token()
+
+
+@responses.activate
+def test_client_credentials_auth_success():
+    """Test successful client credentials authentication."""
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "client_creds_token_12345",
+            "expires_in": 7200,
+            "token_type": "Bearer",
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
+
+    auth = ClientCredentialsAuthenticator(
+        login_url="https://test.salesforce.com",
+        client_id="client_id",
+        client_secret="client_secret",
+    )
+
+    token = auth.get_oauth_token()
+    assert token == "client_creds_token_12345"
+
+    # Verify request parameters
+    assert len(responses.calls) == 1
+    request_body = responses.calls[0].request.body
+    assert "grant_type=client_credentials" in request_body
+    assert "client_id=client_id" in request_body
+    assert "client_secret=client_secret" in request_body
+
+
+@responses.activate
+def test_client_credentials_auth_failure():
+    """Test failed client credentials authentication."""
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={"error": "invalid_client"},
+        status=401,
+    )
+
+    from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
+
+    auth = ClientCredentialsAuthenticator(
+        login_url="https://test.salesforce.com",
+        client_id="invalid_client",
+        client_secret="wrong_secret",
+    )
+
+    with pytest.raises(OperationalError):
+        auth.get_oauth_token()

--- a/salesforce_datacloud_connector/tests/test_auth.py
+++ b/salesforce_datacloud_connector/tests/test_auth.py
@@ -2,7 +2,6 @@
 Tests for OAuth authentication.
 """
 
-import time
 from unittest.mock import patch
 
 import pytest
@@ -66,46 +65,15 @@ def test_username_password_auth_failure():
 
 
 @responses.activate
-def test_token_caching():
-    """Test that tokens are cached and reused."""
-    responses.add(
-        responses.POST,
-        "https://test.salesforce.com/services/oauth2/token",
-        json={
-            "access_token": "cached_token",
-            "expires_in": 7200,
-            "instance_url": "https://myorg.my.salesforce.com",
-        },
-        status=200,
-    )
-
-    auth = UsernamePasswordAuthenticator(
-        login_url="https://test.salesforce.com",
-        username="test@example.com",
-        password="password123",
-        client_id="client_id",
-        client_secret="client_secret",
-    )
-
-    # First call - should hit the API
-    token1 = auth.get_oauth_token()
-    assert len(responses.calls) == 1
-
-    # Second call - should use cached token
-    token2 = auth.get_oauth_token()
-    assert len(responses.calls) == 1  # No additional API call
-    assert token1 == token2
-
-
-@responses.activate
-def test_token_refresh_before_expiry():
-    """Test that tokens are refreshed before they expire (60s buffer)."""
+def test_token_not_cached_fetches_each_call():
+    """Core tokens are never cached (matches JDBC's getOAuthToken()): each
+    get_oauth_token() call fetches fresh, even back-to-back."""
     responses.add(
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
         json={
             "access_token": "token1",
-            "expires_in": 100,  # 100 seconds
+            "expires_in": 7200,
             "instance_url": "https://myorg.my.salesforce.com",
         },
         status=200,
@@ -129,16 +97,15 @@ def test_token_refresh_before_expiry():
         client_secret="client_secret",
     )
 
-    # Get first token
+    # First call - hits the API
     token1 = auth.get_oauth_token()
     assert token1 == "token1"
+    assert len(responses.calls) == 1
 
-    # Simulate time passing (50 seconds - within 60s buffer of expiry)
-    with patch("time.time", return_value=time.time() + 50):
-        token2 = auth.get_oauth_token()
-        # Should get new token because we're within 60s of expiry
-        assert token2 == "token2"
-        assert len(responses.calls) == 2
+    # Second call - fetches again rather than reusing a cache
+    token2 = auth.get_oauth_token()
+    assert token2 == "token2"
+    assert len(responses.calls) == 2
 
 
 @responses.activate
@@ -198,41 +165,6 @@ def test_refresh_token_auth_success():
     assert token == "refresh_access_token"
 
 
-def test_token_invalidation():
-    """Test that token invalidation forces a new fetch."""
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            "https://test.salesforce.com/services/oauth2/token",
-            json={"access_token": "token1", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
-            status=200,
-        )
-        rsps.add(
-            responses.POST,
-            "https://test.salesforce.com/services/oauth2/token",
-            json={"access_token": "token2", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
-            status=200,
-        )
-
-        auth = UsernamePasswordAuthenticator(
-            login_url="https://test.salesforce.com",
-            username="test@example.com",
-            password="password123",
-            client_id="client_id",
-            client_secret="client_secret",
-        )
-
-        # Get first token
-        token1 = auth.get_oauth_token()
-        assert token1 == "token1"
-
-        # Invalidate and get new token
-        auth.invalidate_token()
-        token2 = auth.get_oauth_token()
-        assert token2 == "token2"
-        assert len(rsps.calls) == 2
-
-
 @responses.activate
 def test_login_url_trailing_slash():
     """Test that login URL trailing slashes are handled correctly."""
@@ -278,14 +210,15 @@ def test_get_instance_url():
         client_secret="client_secret",
     )
 
-    # Get instance URL should trigger OAuth fetch if not cached
+    # Get instance URL should trigger an OAuth fetch since none has happened yet
     instance_url = auth.get_instance_url()
     assert instance_url == "https://myorg.my.salesforce.com"
+    assert len(responses.calls) == 1
 
-    # Verify token was also cached
+    # get_oauth_token() fetches fresh again (no core-token caching)
     token = auth.get_oauth_token()
     assert token == "test_token"
-    assert len(responses.calls) == 1  # Only one API call
+    assert len(responses.calls) == 2
 
 
 @responses.activate

--- a/salesforce_datacloud_connector/tests/test_ci_configuration.py
+++ b/salesforce_datacloud_connector/tests/test_ci_configuration.py
@@ -1,0 +1,171 @@
+"""Tests for CI configuration files (Dependabot, GitHub Actions workflows)."""
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ImportError:
+    pytest.skip("PyYAML not installed (not a required dependency)", allow_module_level=True)
+
+
+# This test file lives at salesforce_datacloud_connector/tests/test_ci_configuration.py.
+# .github/ lives at the TRUE repo root, three parents up (tests -> package-subdir -> repo root).
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+class TestDependabotConfiguration:
+    """Tests for .github/dependabot.yml."""
+
+    def test_dependabot_file_exists(self):
+        """Verify Dependabot configuration file exists."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        assert dependabot_path.exists(), "Dependabot configuration file not found"
+
+    def test_dependabot_yaml_valid(self):
+        """Verify Dependabot YAML is valid and parses without errors."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+        assert config is not None, "Dependabot config is empty"
+        assert "version" in config, "Missing 'version' key"
+        assert config["version"] == 2, "Dependabot version must be 2"
+
+    def test_dependabot_has_v1_and_v2_pip_updates(self):
+        """Verify Dependabot configures separate updates for v1 (root) and v2 (subdir)."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        assert "updates" in config, "Missing 'updates' key"
+        pip_updates = [u for u in config["updates"] if u["package-ecosystem"] == "pip"]
+        assert len(pip_updates) >= 2, "Expected at least 2 pip update configurations (v1 + v2)"
+
+        directories = {u["directory"] for u in pip_updates}
+        assert "/" in directories, "Missing v1 pip updates (root directory)"
+        assert "/salesforce_datacloud_connector" in directories, "Missing v2 pip updates (subdir)"
+
+    def test_dependabot_v1_ignores_major_updates(self):
+        """Verify v1 (deprecated) ignores major version updates."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        v1_update = next(u for u in config["updates"] if u["directory"] == "/")
+        assert "ignore" in v1_update, "V1 should have 'ignore' rules"
+
+        ignores = v1_update["ignore"]
+        major_ignore = next(
+            (i for i in ignores if "version-update:semver-major" in i.get("update-types", [])),
+            None,
+        )
+        assert major_ignore is not None, "V1 must ignore major version updates (deprecated)"
+
+    def test_dependabot_v2_allows_major_updates(self):
+        """Verify v2 (active) allows major version updates."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        v2_update = next(u for u in config["updates"] if u["directory"] == "/salesforce_datacloud_connector")
+        if "ignore" in v2_update:
+            ignores = v2_update["ignore"]
+            major_ignore = next(
+                (i for i in ignores if "version-update:semver-major" in i.get("update-types", [])),
+                None,
+            )
+            assert major_ignore is None, "V2 should NOT ignore major version updates"
+
+    def test_dependabot_has_github_actions_updates(self):
+        """Verify Dependabot configures GitHub Actions dependency updates."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        actions_updates = [u for u in config["updates"] if u["package-ecosystem"] == "github-actions"]
+        assert len(actions_updates) >= 1, "Expected at least 1 github-actions update configuration"
+        assert actions_updates[0]["directory"] == "/", "GitHub Actions updates should target root"
+
+    def test_dependabot_weekly_schedule(self):
+        """Verify all updates run on a weekly schedule."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        for update in config["updates"]:
+            assert "schedule" in update, f"Missing schedule for {update['package-ecosystem']}"
+            assert update["schedule"]["interval"] == "weekly", f"Expected weekly interval for {update['directory']}"
+
+    def test_dependabot_commit_message_prefixes(self):
+        """Verify distinct commit message prefixes for v1, v2, and actions."""
+        dependabot_path = REPO_ROOT / ".github" / "dependabot.yml"
+        with open(dependabot_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        prefixes = {}
+        for update in config["updates"]:
+            directory = update["directory"]
+            ecosystem = update["package-ecosystem"]
+            prefix = update.get("commit-message", {}).get("prefix", "")
+            prefixes[f"{ecosystem}:{directory}"] = prefix
+
+        assert prefixes.get("pip:/", "") == "deps(v1):", "V1 prefix must be 'deps(v1):'"
+        assert prefixes.get("pip:/salesforce_datacloud_connector", "") == "deps(v2):", "V2 prefix must be 'deps(v2):'"
+        assert prefixes.get("github-actions:/", "") == "deps(actions):", "Actions prefix must be 'deps(actions):'"
+
+
+class TestV2WorkflowConfiguration:
+    """Tests for .github/workflows/v2-package.yml."""
+
+    def test_v2_workflow_file_exists(self):
+        """Verify v2 workflow file exists."""
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "v2-package.yml"
+        assert workflow_path.exists(), "V2 workflow file not found"
+
+    def test_v2_workflow_yaml_valid(self):
+        """Verify v2 workflow YAML is valid and parses without errors."""
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "v2-package.yml"
+        with open(workflow_path, "r") as f:
+            config = yaml.safe_load(f)
+        assert config is not None, "V2 workflow config is empty"
+        assert "jobs" in config, "Missing 'jobs' key"
+
+    def test_v2_workflow_runs_ruff(self):
+        """Verify v2 workflow runs ruff linting for both package and tests."""
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "v2-package.yml"
+        with open(workflow_path, "r") as f:
+            content = f.read()
+
+        assert "ruff check salesforce_datacloud_connector" in content, "Missing ruff check for package"
+        assert "ruff check tests" in content, "Missing ruff check for tests"
+
+    def test_v2_workflow_runs_pytest_with_marker_filter(self):
+        """Verify v2 workflow runs pytest with 'not e2e' marker filter."""
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "v2-package.yml"
+        with open(workflow_path, "r") as f:
+            content = f.read()
+
+        assert 'pytest -m "not e2e"' in content, "Missing pytest marker filter (must skip e2e tests)"
+
+    def test_v2_workflow_python_matrix(self):
+        """Verify v2 workflow tests Python 3.8, 3.9, 3.10, 3.11."""
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "v2-package.yml"
+        with open(workflow_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        matrix = config["jobs"]["test"]["strategy"]["matrix"]
+        assert "python-version" in matrix, "Missing python-version matrix"
+        versions = matrix["python-version"]
+        assert set(versions) == {"3.8", "3.9", "3.10", "3.11"}, f"Unexpected Python versions: {versions}"
+
+    def test_v2_workflow_working_directory(self):
+        """Verify v2 workflow sets working directory to salesforce_datacloud_connector."""
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "v2-package.yml"
+        with open(workflow_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        defaults = config["jobs"]["test"].get("defaults", {})
+        run_config = defaults.get("run", {})
+        working_dir = run_config.get("working-directory", "")
+        assert working_dir == "salesforce_datacloud_connector", f"Unexpected working directory: {working_dir}"

--- a/salesforce_datacloud_connector/tests/test_connection.py
+++ b/salesforce_datacloud_connector/tests/test_connection.py
@@ -6,18 +6,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from salesforce_datacloud_connector.auth.oauth import OAuthAuthenticator
 from salesforce_datacloud_connector.connection import Connection
 from salesforce_datacloud_connector.cursor import Cursor
 from salesforce_datacloud_connector.exceptions import InterfaceError
 
 
 def create_mock_authenticator():
-    """Create a mock authenticator for testing."""
-    auth = Mock(spec=OAuthAuthenticator)
-    auth.get_instance_url.return_value = "https://test.salesforce.com"
-    auth.get_oauth_token.return_value = "mock_token"
-    return auth
+    """Create a mock token provider for testing."""
+    provider = Mock()
+    provider.get_tenant_endpoint.return_value = "https://test.c360a.salesforce.com"
+    provider.get_cdp_token.return_value = "mock_cdp_token"
+    return provider
 
 
 def test_connection_initialization():
@@ -173,3 +172,86 @@ def test_no_workload_by_default():
     conn = Connection(auth)
 
     assert conn.workload is None
+
+
+def test_connect_wires_token_exchanger():
+    """Test that connect() creates DataCloudTokenExchanger and passes it to Connection."""
+    from unittest.mock import patch
+    import salesforce_datacloud_connector as sfdc
+    from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
+    from salesforce_datacloud_connector.auth.oauth import JWTAuthenticator
+
+    # Mock the JWT authenticator's token fetch, the exchange, and the revoke
+    # (patch _revoke_core_token so no live HTTP call escapes during connect()).
+    with patch.object(JWTAuthenticator, '_fetch_new_token', return_value=("core_token", 7200, "https://test.salesforce.com")), \
+         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")), \
+         patch.object(DataCloudTokenExchanger, '_revoke_core_token', return_value=None):
+            # Create connection via connect()
+            conn = sfdc.connect(
+                login_url="https://login.salesforce.com",
+                auth_type="jwt",
+                username="test@example.com",
+                client_id="test_client_id",
+                jwt_private_key="-----BEGIN PRIVATE KEY-----\ntest_key\n-----END PRIVATE KEY-----",
+                dataspace="test_ds",
+                workload="test_workload"
+            )
+
+            # Verify connection is created
+            assert conn is not None
+            assert isinstance(conn, sfdc.Connection)
+
+            # Verify the client has the correct tenant endpoint (from CDP exchange)
+            assert conn._client.tenant_endpoint == "https://tenant.c360a.salesforce.com"
+
+            # Verify token provider is DataCloudTokenExchanger
+            assert isinstance(conn._token_provider, DataCloudTokenExchanger)
+
+            conn.close()
+
+
+def test_connect_wires_client_credentials():
+    """Test that connect(auth_type='client_credentials') composes the client-credentials
+    authenticator → DataCloudTokenExchanger → Connection (GA go-forward path)."""
+    from unittest.mock import patch
+    import salesforce_datacloud_connector as sfdc
+    from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
+    from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
+
+    # Mock the client-credentials authenticator's token fetch (no user/JWT needed).
+    # Patch _revoke_core_token too so no live HTTP call escapes during connect().
+    with patch.object(ClientCredentialsAuthenticator, '_fetch_new_token', return_value=("core_token", 7200, "https://test.salesforce.com")), \
+         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")), \
+         patch.object(DataCloudTokenExchanger, '_revoke_core_token', return_value=None):
+            conn = sfdc.connect(
+                login_url="https://login.salesforce.com",
+                auth_type="client_credentials",
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                dataspace="test_ds",
+                workload="test_workload",
+            )
+
+            assert conn is not None
+            assert isinstance(conn, sfdc.Connection)
+            # Composed authenticator is the client-credentials flow
+            assert isinstance(conn._token_provider._core_authenticator, ClientCredentialsAuthenticator)
+            # Tenant endpoint flows through from the CDP exchange
+            assert conn._client.tenant_endpoint == "https://tenant.c360a.salesforce.com"
+            assert isinstance(conn._token_provider, DataCloudTokenExchanger)
+
+            conn.close()
+
+
+def test_connect_client_credentials_requires_secret():
+    """connect(auth_type='client_credentials') must reject missing client_secret."""
+    import pytest
+    import salesforce_datacloud_connector as sfdc
+
+    with pytest.raises(ValueError, match="client_credentials auth requires"):
+        sfdc.connect(
+            login_url="https://login.salesforce.com",
+            auth_type="client_credentials",
+            client_id="test_client_id",
+            # client_secret intentionally omitted
+        )

--- a/salesforce_datacloud_connector/tests/test_connection.py
+++ b/salesforce_datacloud_connector/tests/test_connection.py
@@ -181,11 +181,9 @@ def test_connect_wires_token_exchanger():
     from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
     from salesforce_datacloud_connector.auth.oauth import JWTAuthenticator
 
-    # Mock the JWT authenticator's token fetch, the exchange, and the revoke
-    # (patch _revoke_core_token so no live HTTP call escapes during connect()).
+    # Mock the JWT authenticator's token fetch and the exchange.
     with patch.object(JWTAuthenticator, '_fetch_new_token', return_value=("core_token", 7200, "https://test.salesforce.com")), \
-         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")), \
-         patch.object(DataCloudTokenExchanger, '_revoke_core_token', return_value=None):
+         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")):
             # Create connection via connect()
             conn = sfdc.connect(
                 login_url="https://login.salesforce.com",
@@ -219,10 +217,8 @@ def test_connect_wires_client_credentials():
     from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
 
     # Mock the client-credentials authenticator's token fetch (no user/JWT needed).
-    # Patch _revoke_core_token too so no live HTTP call escapes during connect().
     with patch.object(ClientCredentialsAuthenticator, '_fetch_new_token', return_value=("core_token", 7200, "https://test.salesforce.com")), \
-         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")), \
-         patch.object(DataCloudTokenExchanger, '_revoke_core_token', return_value=None):
+         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")):
             conn = sfdc.connect(
                 login_url="https://login.salesforce.com",
                 auth_type="client_credentials",

--- a/salesforce_datacloud_connector/tests/test_connection.py
+++ b/salesforce_datacloud_connector/tests/test_connection.py
@@ -11,7 +11,7 @@ from salesforce_datacloud_connector.cursor import Cursor
 from salesforce_datacloud_connector.exceptions import InterfaceError
 
 
-def create_mock_authenticator():
+def create_mock_token_provider():
     """Create a mock token provider for testing."""
     provider = Mock()
     provider.get_tenant_endpoint.return_value = "https://test.c360a.salesforce.com"
@@ -21,7 +21,7 @@ def create_mock_authenticator():
 
 def test_connection_initialization():
     """Test connection initialization."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth, dataspace="test_space", workload="test_workload")
 
     assert not conn.closed
@@ -31,7 +31,7 @@ def test_connection_initialization():
 
 def test_create_cursor():
     """Test creating a cursor from connection."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     cursor = conn.cursor()
@@ -42,7 +42,7 @@ def test_create_cursor():
 
 def test_create_multiple_cursors():
     """Test creating multiple cursors from same connection."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     cursor1 = conn.cursor()
@@ -55,7 +55,7 @@ def test_create_multiple_cursors():
 
 def test_close_connection():
     """Test closing a connection."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     assert not conn.closed
@@ -67,7 +67,7 @@ def test_close_connection():
 
 def test_operations_after_close():
     """Test that operations fail after connection is closed."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     conn.close()
@@ -84,7 +84,7 @@ def test_operations_after_close():
 
 def test_commit_noop():
     """Test that commit() is a no-op for read-only driver."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     # Should not raise
@@ -93,7 +93,7 @@ def test_commit_noop():
 
 def test_rollback_noop():
     """Test that rollback() is a no-op for read-only driver."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     # Should not raise
@@ -102,7 +102,7 @@ def test_rollback_noop():
 
 def test_context_manager():
     """Test connection as context manager."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
 
     with Connection(auth) as conn:
         assert not conn.closed
@@ -115,7 +115,7 @@ def test_context_manager():
 
 def test_context_manager_with_exception():
     """Test that connection is closed even if exception occurs."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
 
     try:
         with Connection(auth) as conn:
@@ -129,7 +129,7 @@ def test_context_manager_with_exception():
 
 def test_multiple_close_calls():
     """Test that multiple close() calls are safe."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     conn.close()
@@ -142,7 +142,7 @@ def test_multiple_close_calls():
 
 def test_dataspace_property():
     """Test dataspace property."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth, dataspace="custom_space")
 
     assert conn.dataspace == "custom_space"
@@ -150,7 +150,7 @@ def test_dataspace_property():
 
 def test_workload_property():
     """Test workload property."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth, workload="my_app")
 
     assert conn.workload == "my_app"
@@ -158,7 +158,7 @@ def test_workload_property():
 
 def test_default_dataspace():
     """Test default dataspace is None (server applies the org default)."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     # When no dataspace is supplied the connector forwards None to the API
@@ -168,7 +168,7 @@ def test_default_dataspace():
 
 def test_no_workload_by_default():
     """Test that workload is None by default."""
-    auth = create_mock_authenticator()
+    auth = create_mock_token_provider()
     conn = Connection(auth)
 
     assert conn.workload is None

--- a/salesforce_datacloud_connector/tests/test_cursor.py
+++ b/salesforce_datacloud_connector/tests/test_cursor.py
@@ -441,3 +441,99 @@ def test_fetch_df_raises_clear_error_without_pandas():
     with patch("builtins.__import__", side_effect=_no_pandas):
         with pytest.raises(ImportError, match=r"salesforce-datacloud\[pandas\]"):
             cursor.fetch_df()
+
+
+def test_get_query_status_before_execute():
+    """get_query_status() returns None before any query has run."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    assert cursor.get_query_status() is None
+
+
+def test_get_query_status_after_sync_execute():
+    """For a synchronous query, returns the status from the initial response."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    status = QueryStatus(
+        query_id="q1",
+        completion_status="ResultsProduced",
+        progress=1.0,
+        row_count=2,
+        chunk_count=1,
+    )
+    client.execute_query.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=2,
+        status=status,
+    )
+
+    cursor.execute("SELECT name FROM users")
+
+    observed = cursor.get_query_status()
+    assert observed is status
+    # Non-blocking: get_query_status() must NOT issue a status HTTP call.
+    client.get_query_status.assert_not_called()
+
+
+def test_get_query_status_after_async_poll():
+    """For an async query, returns the final polled status, not the initial Running one."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="RUNNING",
+            progress=0.1,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    final = QueryStatus(
+        query_id="q1",
+        completion_status="Finished",
+        progress=1.0,
+        row_count=2,
+        chunk_count=1,
+    )
+    client.poll_until_complete.return_value = final
+    client.fetch_results.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[],
+        returned_rows=2,
+    )
+
+    cursor.execute("SELECT name FROM huge_table")
+
+    assert cursor.get_query_status() is final
+    client.get_query_status.assert_not_called()
+
+
+def test_get_query_status_after_close_raises():
+    """A closed cursor must not return stale status."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    cursor.execute("SELECT 1")
+    cursor.close()
+
+    with pytest.raises(InterfaceError):
+        cursor.get_query_status()

--- a/salesforce_datacloud_connector/tests/test_cursor.py
+++ b/salesforce_datacloud_connector/tests/test_cursor.py
@@ -394,3 +394,50 @@ def test_fetch_before_execute():
 
     with pytest.raises(InterfaceError):
         cursor.fetchmany(10)
+
+
+def test_fetch_df_returns_dataframe_when_pandas_present():
+    """R6: fetch_df() returns a pandas DataFrame built from the fetched rows + description."""
+    import pytest
+    pytest.importorskip("pandas")  # only run when the [pandas] extra is installed
+
+    from unittest.mock import Mock
+    from salesforce_datacloud_connector.cursor import Cursor
+
+    cursor = Cursor(Mock())
+    # Simulate an executed query with results:
+    # _check_query_executed() passes when _query_id is not None; _closed defaults to False.
+    cursor._query_id = "query123"
+    cursor._description = [("name", None, None, None, None, None, None),
+                           ("age", None, None, None, None, None, None)]
+    cursor.fetchall = Mock(return_value=[("Alice", 30), ("Bob", 25)])
+
+    df = cursor.fetch_df()
+
+    assert list(df.columns) == ["name", "age"]
+    assert len(df) == 2
+    assert df.iloc[0]["name"] == "Alice"
+
+
+def test_fetch_df_raises_clear_error_without_pandas():
+    """R6: fetch_df() raises an actionable ImportError when pandas is not installed."""
+    import builtins
+    import pytest
+    from unittest.mock import Mock, patch
+    from salesforce_datacloud_connector.cursor import Cursor
+
+    cursor = Cursor(Mock())
+    cursor._query_id = "query123"
+    cursor._description = [("name", None, None, None, None, None, None)]
+    cursor.fetchall = Mock(return_value=[("Alice",)])
+
+    real_import = builtins.__import__
+
+    def _no_pandas(name, *args, **kwargs):
+        if name == "pandas":
+            raise ImportError("No module named 'pandas'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_no_pandas):
+        with pytest.raises(ImportError, match=r"salesforce-datacloud\[pandas\]"):
+            cursor.fetch_df()

--- a/salesforce_datacloud_connector/tests/test_e2e_offcore_smoke.py
+++ b/salesforce_datacloud_connector/tests/test_e2e_offcore_smoke.py
@@ -1,0 +1,248 @@
+"""
+End-to-End Smoke Test — Off-Core Query v3 (JWT Auth)
+
+This test verifies the full off-core query path:
+1. Authenticate via JWT bearer token
+2. Exchange core token for CDP token + tenant endpoint
+3. Execute a synthetic query against off-core v3 (`generate_series`)
+4. Verify results
+
+Requires environment variables:
+  SFDC_LOGIN_URL        — e.g., "https://login.salesforce.com"
+  SFDC_USERNAME         — Connected app user
+  SFDC_CLIENT_ID        — Connected app client ID
+  SFDC_JWT_PRIVATE_KEY  — Path to private key PEM file, or literal key
+  SFDC_DATASPACE        — Optional dataspace (default: "default")
+
+Synthetic query pattern (no tenant data required):
+  SELECT n FROM generate_series(1, 10) AS t(n)
+
+This test is gated by @pytest.mark.e2e and skipped in CI.
+"""
+
+import os
+import pytest
+
+import salesforce_datacloud_connector as sfdc
+
+pytestmark = pytest.mark.e2e
+
+
+# Test configuration from environment
+TEST_CONFIG = {
+    "login_url": os.getenv("SFDC_LOGIN_URL"),
+    "username": os.getenv("SFDC_USERNAME"),
+    "client_id": os.getenv("SFDC_CLIENT_ID"),
+    "jwt_private_key_path": os.getenv("SFDC_JWT_PRIVATE_KEY_PATH"),
+    "jwt_private_key": os.getenv("SFDC_JWT_PRIVATE_KEY"),
+    "dataspace": os.getenv("SFDC_DATASPACE", "default"),
+    "workload": "python-connector-e2e-smoke",
+}
+
+
+def get_private_key():
+    """Load private key from path or env var."""
+    if TEST_CONFIG["jwt_private_key"]:
+        return TEST_CONFIG["jwt_private_key"]
+    elif TEST_CONFIG["jwt_private_key_path"]:
+        with open(TEST_CONFIG["jwt_private_key_path"], "r") as f:
+            return f.read()
+    else:
+        return None
+
+
+# Validate required configuration at module load time
+if not all([TEST_CONFIG["login_url"], TEST_CONFIG["username"], TEST_CONFIG["client_id"]]):
+    pytest.skip(
+        "Off-core e2e smoke test requires SFDC_LOGIN_URL, SFDC_USERNAME, "
+        "and SFDC_CLIENT_ID environment variables.",
+        allow_module_level=True,
+    )
+
+if not get_private_key():
+    pytest.skip(
+        "Off-core e2e smoke test requires SFDC_JWT_PRIVATE_KEY or "
+        "SFDC_JWT_PRIVATE_KEY_PATH environment variable.",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def offcore_connection():
+    """Create connection to off-core v3 via JWT auth."""
+    conn = sfdc.connect(
+        login_url=TEST_CONFIG["login_url"],
+        auth_type="jwt",
+        username=TEST_CONFIG["username"],
+        client_id=TEST_CONFIG["client_id"],
+        jwt_private_key=get_private_key(),
+        dataspace=TEST_CONFIG["dataspace"],
+        workload=TEST_CONFIG["workload"],
+    )
+    yield conn
+    conn.close()
+
+
+class TestOffCoreSmoke:
+    """Smoke tests for off-core v3 query path."""
+
+    def test_connection_established(self, offcore_connection):
+        """Test that connection is established."""
+        assert offcore_connection is not None
+        assert not offcore_connection.closed
+        assert isinstance(offcore_connection, sfdc.Connection)
+
+    def test_cursor_creation(self, offcore_connection):
+        """Test that cursor can be created."""
+        cursor = offcore_connection.cursor()
+        assert cursor is not None
+        cursor.close()
+
+    def test_synthetic_query_generate_series(self, offcore_connection):
+        """
+        Test synthetic query via generate_series (no tenant data required).
+
+        This verifies the full off-core v3 stack:
+        - JWT auth → core token
+        - Token exchange → CDP token + tenant endpoint
+        - POST /api/v3/query with SQL
+        - Parse x-hyperdb-status header
+        - Fetch results
+        """
+        cursor = offcore_connection.cursor()
+
+        # Execute synthetic query
+        cursor.execute("SELECT n FROM generate_series(1, 10) AS t(n)")
+
+        # Verify cursor.description (metadata)
+        assert cursor.description is not None
+        assert len(cursor.description) == 1
+        col_name, col_type, *_ = cursor.description[0]
+        assert col_name.lower() == "n"
+        assert col_type == sfdc.NUMBER  # generate_series returns integers
+
+        # Fetch results
+        rows = cursor.fetchall()
+        assert len(rows) == 10
+
+        # Verify data: should be [(1,), (2,), ..., (10,)]
+        expected = [(i,) for i in range(1, 11)]
+        assert rows == expected
+
+        cursor.close()
+
+    def test_synthetic_query_count(self, offcore_connection):
+        """Test COUNT aggregation over synthetic data."""
+        cursor = offcore_connection.cursor()
+        cursor.execute("SELECT COUNT(*) FROM generate_series(1, 100) AS t(n)")
+
+        result = cursor.fetchone()
+        assert result is not None
+        assert len(result) == 1
+        assert result[0] == 100
+
+        cursor.close()
+
+    def test_synthetic_query_with_filter(self, offcore_connection):
+        """Test WHERE clause over synthetic data."""
+        cursor = offcore_connection.cursor()
+        cursor.execute(
+            "SELECT n FROM generate_series(1, 20) AS t(n) WHERE n > 15 ORDER BY n"
+        )
+
+        rows = cursor.fetchall()
+        assert len(rows) == 5  # 16, 17, 18, 19, 20
+        assert rows == [(16,), (17,), (18,), (19,), (20,)]
+
+        cursor.close()
+
+    def test_fetch_methods(self, offcore_connection):
+        """Test fetchone/fetchmany/fetchall."""
+        cursor = offcore_connection.cursor()
+        cursor.execute("SELECT n FROM generate_series(1, 10) AS t(n)")
+
+        # fetchone
+        row1 = cursor.fetchone()
+        assert row1 == (1,)
+
+        # fetchmany(3)
+        rows_many = cursor.fetchmany(3)
+        assert rows_many == [(2,), (3,), (4,)]
+
+        # fetchall (remaining)
+        rows_all = cursor.fetchall()
+        assert rows_all == [(5,), (6,), (7,), (8,), (9,), (10,)]
+
+        cursor.close()
+
+    def test_cursor_iteration(self, offcore_connection):
+        """Test cursor iteration over results."""
+        cursor = offcore_connection.cursor()
+        cursor.execute("SELECT n FROM generate_series(1, 5) AS t(n)")
+
+        collected = []
+        for row in cursor:
+            collected.append(row)
+
+        assert collected == [(1,), (2,), (3,), (4,), (5,)]
+        cursor.close()
+
+    def test_multiple_cursors(self, offcore_connection):
+        """Test multiple cursors on same connection."""
+        cursor1 = offcore_connection.cursor()
+        cursor2 = offcore_connection.cursor()
+
+        cursor1.execute("SELECT COUNT(*) FROM generate_series(1, 10) AS t(n)")
+        cursor2.execute("SELECT COUNT(*) FROM generate_series(1, 10) AS t(n)")
+
+        count1 = cursor1.fetchone()[0]
+        count2 = cursor2.fetchone()[0]
+
+        assert count1 == count2 == 10
+
+        cursor1.close()
+        cursor2.close()
+
+    def test_context_manager(self, offcore_connection):
+        """Test cursor context manager."""
+        with offcore_connection.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) FROM generate_series(1, 5) AS t(n)")
+            count = cursor.fetchone()[0]
+            assert count == 5
+        # Cursor should be closed after context
+
+    def test_error_invalid_sql(self, offcore_connection):
+        """Test that invalid SQL raises ProgrammingError."""
+        cursor = offcore_connection.cursor()
+
+        with pytest.raises(sfdc.ProgrammingError):
+            cursor.execute("INVALID SQL SYNTAX HERE")
+
+        cursor.close()
+
+    def test_error_invalid_table(self, offcore_connection):
+        """Test that non-existent table raises ProgrammingError."""
+        cursor = offcore_connection.cursor()
+
+        with pytest.raises(sfdc.ProgrammingError):
+            cursor.execute("SELECT * FROM NonexistentTable123")
+
+        cursor.close()
+
+
+def test_smoke_summary(capsys):
+    """Print summary of e2e smoke test configuration."""
+    print("\n" + "="*70)
+    print("Off-Core v3 E2E Smoke Test Configuration")
+    print("="*70)
+    print(f"Login URL: {TEST_CONFIG['login_url']}")
+    print(f"Username: {TEST_CONFIG['username']}")
+    print(f"Client ID: {TEST_CONFIG['client_id'][:20]}..." if TEST_CONFIG['client_id'] else "Client ID: (not set)")
+    print(f"Dataspace: {TEST_CONFIG['dataspace']}")
+    print(f"Workload: {TEST_CONFIG['workload']}")
+    print(f"Private key: {'(loaded from path)' if TEST_CONFIG['jwt_private_key_path'] else '(loaded from env)'}")
+    print("="*70)
+    print("\nTo run this test:")
+    print("  pytest tests/test_e2e_offcore_smoke.py -v")
+    print("\nOr with explicit e2e marker:")
+    print("  pytest -m e2e tests/test_e2e_offcore_smoke.py -v")

--- a/salesforce_datacloud_connector/tests/test_integration.py
+++ b/salesforce_datacloud_connector/tests/test_integration.py
@@ -4,6 +4,8 @@ End-to-end integration tests for the driver.
 These tests verify the complete flow: connect → execute → fetch → close
 """
 
+import json
+
 import pytest
 import responses
 
@@ -23,23 +25,28 @@ def test_end_to_end_sync_query():
     )
 
     # Mock query execution
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 3,
+        "chunkCount": 1,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [["Alice", 30], ["Bob", 25], ["Charlie", 35]],
-            "metadata": [
-                {"name": "name", "type": "Varchar", "nullable": True},
-                {"name": "age", "type": "Numeric", "nullable": False, "scale": 0},
-            ],
-            "returnedRows": 3,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 3,
-                "chunkCount": 1,
+            "metadata": {
+                "columns": [
+                    {"name": "name", "type": "varchar", "nullable": True},
+                    {"name": "age", "type": "numeric", "nullable": False, "scale": 0},
+                ]
             },
+            "data": [["Alice", 30], ["Bob", 25], ["Charlie", 35]],
+            "returnedRows": 3,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
@@ -88,20 +95,25 @@ def test_end_to_end_with_context_managers():
     )
 
     # Mock query
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 1,
+        "chunkCount": 1,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [["Result"]],
-            "metadata": [{"name": "col", "type": "Varchar", "nullable": True}],
-            "returnedRows": 1,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 1,
-                "chunkCount": 1,
+            "metadata": {
+                "columns": [{"name": "col", "type": "varchar", "nullable": True}]
             },
+            "data": [["Result"]],
+            "returnedRows": 1,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
@@ -134,28 +146,28 @@ def test_parameterized_query():
     # Mock query with parameter validation
     def check_parameters(request):
         body = request.body.decode("utf-8")
-        assert '"name": "status"' in body
         assert '"value": "Active"' in body
+        assert '"name"' not in body  # v3 params carry no parameter name
+        status_header = {
+            "queryId": "q1",
+            "completionStatus": "RESULTS_PRODUCED",
+            "progress": 1.0,
+            "rowCount": 1,
+            "chunkCount": 1
+        }
         return (
             200,
-            {},
+            {"x-hyperdb-status": json.dumps(status_header)},
             """{
+                "metadata": {"columns": [{"name": "name", "type": "varchar", "nullable": true}]},
                 "data": [["Alice"]],
-                "metadata": [{"name": "name", "type": "Varchar", "nullable": true}],
-                "returnedRows": 1,
-                "status": {
-                    "queryId": "q1",
-                    "completionStatus": "ResultsProduced",
-                    "progress": 1.0,
-                    "rowCount": 1,
-                    "chunkCount": 1
-                }
+                "returnedRows": 1
             }""",
         )
 
     responses.add_callback(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         callback=check_parameters,
     )
 
@@ -187,20 +199,25 @@ def test_large_result_set_with_pagination():
     )
 
     # Mock initial query (returns first chunk)
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 5,  # Total 5 rows
+        "chunkCount": 3,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [["Row1"], ["Row2"]],
-            "metadata": [{"name": "data", "type": "Varchar", "nullable": True}],
-            "returnedRows": 2,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 5,  # Total 5 rows
-                "chunkCount": 3,
+            "metadata": {
+                "columns": [{"name": "data", "type": "varchar", "nullable": True}]
             },
+            "data": [["Row1"], ["Row2"]],
+            "returnedRows": 2,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
@@ -208,7 +225,7 @@ def test_large_result_set_with_pagination():
     # Mock second chunk
     responses.add(
         responses.GET,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql/q1/rows",
+        "https://myorg.my.salesforce.com/api/v3/query/q1/rows",
         json={"data": [["Row3"], ["Row4"]], "returnedRows": 2},
         status=200,
     )
@@ -216,7 +233,7 @@ def test_large_result_set_with_pagination():
     # Mock third chunk
     responses.add(
         responses.GET,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql/q1/rows",
+        "https://myorg.my.salesforce.com/api/v3/query/q1/rows",
         json={"data": [["Row5"]], "returnedRows": 1},
         status=200,
     )
@@ -251,36 +268,47 @@ def test_async_query_with_polling():
     )
 
     # Mock initial query (async response)
+    initial_status_header = {
+        "queryId": "q1",
+        "completionStatus": "RUNNING_OR_UNSPECIFIED",
+        "progress": 0.5,
+        "rowCount": 0,
+        "chunkCount": 0,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [],
-            "metadata": [{"name": "result", "type": "Varchar", "nullable": True}],
-            "returnedRows": 0,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "Running",
-                "progress": 0.5,
-                "rowCount": 0,
-                "chunkCount": 0,
+            "metadata": {
+                "columns": [{"name": "result", "type": "varchar", "nullable": True}]
             },
+            "data": [],
+            "returnedRows": 0,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(initial_status_header)
         },
         status=200,
     )
 
     # Mock status polling (complete)
+    poll_status_header = {
+        "queryId": "q1",
+        "completionStatus": "FINISHED",
+        "progress": 1.0,
+        "rowCount": 1,
+        "chunkCount": 1,
+    }
     responses.add(
         responses.GET,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql/q1",
+        "https://myorg.my.salesforce.com/api/v3/query/q1",
         json={
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "Finished",
-                "progress": 1.0,
-                "rowCount": 1,
-                "chunkCount": 1,
-            }
+            "metadata": {"columns": []},
+            "data": None,
+            "returnedRows": 0
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(poll_status_header)
         },
         status=200,
     )
@@ -288,7 +316,7 @@ def test_async_query_with_polling():
     # Mock fetching results
     responses.add(
         responses.GET,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql/q1/rows",
+        "https://myorg.my.salesforce.com/api/v3/query/q1/rows",
         json={"data": [["Success"]], "returnedRows": 1},
         status=200,
     )
@@ -353,7 +381,7 @@ def test_sql_syntax_error():
     # Mock SQL error
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={"message": "SQL syntax error near 'INVALID'"},
         status=400,
     )
@@ -384,20 +412,25 @@ def test_cursor_iteration():
     )
 
     # Mock query
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 3,
+        "chunkCount": 1,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [["Alice"], ["Bob"], ["Charlie"]],
-            "metadata": [{"name": "name", "type": "Varchar", "nullable": True}],
-            "returnedRows": 3,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 3,
-                "chunkCount": 1,
+            "metadata": {
+                "columns": [{"name": "name", "type": "varchar", "nullable": True}]
             },
+            "data": [["Alice"], ["Bob"], ["Charlie"]],
+            "returnedRows": 3,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
@@ -429,20 +462,25 @@ def test_jwt_authentication():
     )
 
     # Mock query
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 1,
+        "chunkCount": 1,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [["Test"]],
-            "metadata": [{"name": "col", "type": "Varchar", "nullable": True}],
-            "returnedRows": 1,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 1,
-                "chunkCount": 1,
+            "metadata": {
+                "columns": [{"name": "col", "type": "varchar", "nullable": True}]
             },
+            "data": [["Test"]],
+            "returnedRows": 1,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )
@@ -457,18 +495,16 @@ def test_jwt_authentication():
         )
         rsps.add(
             responses.POST,
-            "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+            "https://myorg.my.salesforce.com/api/v3/query",
             json={
-                "data": [["Test"]],
-                "metadata": [{"name": "col", "type": "Varchar", "nullable": True}],
-                "returnedRows": 1,
-                "status": {
-                    "queryId": "q1",
-                    "completionStatus": "ResultsProduced",
-                    "progress": 1.0,
-                    "rowCount": 1,
-                    "chunkCount": 1,
+                "metadata": {
+                    "columns": [{"name": "col", "type": "varchar", "nullable": True}]
                 },
+                "data": [["Test"]],
+                "returnedRows": 1,
+            },
+            headers={
+                "x-hyperdb-status": json.dumps(status_header)
             },
             status=200,
         )
@@ -508,20 +544,25 @@ def test_refresh_token_authentication():
     )
 
     # Mock query
+    status_header = {
+        "queryId": "q1",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 1,
+        "chunkCount": 1,
+    }
     responses.add(
         responses.POST,
-        "https://myorg.my.salesforce.com/services/data/v64.0/ssot/query-sql",
+        "https://myorg.my.salesforce.com/api/v3/query",
         json={
-            "data": [["Test"]],
-            "metadata": [{"name": "col", "type": "Varchar", "nullable": True}],
-            "returnedRows": 1,
-            "status": {
-                "queryId": "q1",
-                "completionStatus": "ResultsProduced",
-                "progress": 1.0,
-                "rowCount": 1,
-                "chunkCount": 1,
+            "metadata": {
+                "columns": [{"name": "col", "type": "varchar", "nullable": True}]
             },
+            "data": [["Test"]],
+            "returnedRows": 1,
+        },
+        headers={
+            "x-hyperdb-status": json.dumps(status_header)
         },
         status=200,
     )

--- a/salesforce_datacloud_connector/tests/test_integration.py
+++ b/salesforce_datacloud_connector/tests/test_integration.py
@@ -24,6 +24,14 @@ def test_end_to_end_sync_query():
         status=200,
     )
 
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
     # Mock query execution
     status_header = {
         "queryId": "q1",
@@ -94,6 +102,14 @@ def test_end_to_end_with_context_managers():
         status=200,
     )
 
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
     # Mock query
     status_header = {
         "queryId": "q1",
@@ -140,6 +156,14 @@ def test_parameterized_query():
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
         json={"access_token": "token123", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
         status=200,
     )
 
@@ -195,6 +219,14 @@ def test_large_result_set_with_pagination():
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
         json={"access_token": "token123", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
         status=200,
     )
 
@@ -264,6 +296,14 @@ def test_async_query_with_polling():
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
         json={"access_token": "token123", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
         status=200,
     )
 
@@ -347,6 +387,14 @@ def test_unsupported_dml_operations():
         status=200,
     )
 
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
     with sfdc.connect(
         login_url="https://test.salesforce.com",
         auth_type="username_password",
@@ -375,6 +423,14 @@ def test_sql_syntax_error():
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
         json={"access_token": "token123", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
         status=200,
     )
 
@@ -408,6 +464,14 @@ def test_cursor_iteration():
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
         json={"access_token": "token123", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
         status=200,
     )
 
@@ -495,6 +559,12 @@ def test_jwt_authentication():
         )
         rsps.add(
             responses.POST,
+            "https://myorg.my.salesforce.com/services/a360/token",
+            json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
+            status=200,
+        )
+        rsps.add(
+            responses.POST,
             "https://myorg.my.salesforce.com/api/v3/query",
             json={
                 "metadata": {
@@ -540,6 +610,14 @@ def test_refresh_token_authentication():
             "token_type": "Bearer",
             "instance_url": "https://myorg.my.salesforce.com",
         },
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"access_token": "cdp_token", "expires_in": 7200, "instance_url": "https://myorg.my.salesforce.com"},
         status=200,
     )
 

--- a/salesforce_datacloud_connector/tests/test_metadata.py
+++ b/salesforce_datacloud_connector/tests/test_metadata.py
@@ -1,0 +1,45 @@
+"""Tests for package metadata and version information."""
+
+import salesforce_datacloud_connector as sfdc
+
+
+def test_version_is_set():
+    """Test that __version__ is defined."""
+    assert hasattr(sfdc, "__version__")
+    assert isinstance(sfdc.__version__, str)
+    assert len(sfdc.__version__) > 0
+
+
+def test_version_format():
+    """Test that __version__ follows semantic versioning."""
+    version = sfdc.__version__
+
+    # Should match pattern: MAJOR.MINOR.PATCH[alpha/beta/rc suffix]
+    # e.g., "2.0.0b2" or "2.0.0"
+    parts = version.split(".")
+    assert len(parts) >= 2, f"Version should have at least MAJOR.MINOR: {version}"
+
+    # Major and minor should be numeric (patch may have suffix like 0b2)
+    assert parts[0].isdigit(), f"Major version should be numeric: {parts[0]}"
+    assert parts[1].isdigit(), f"Minor version should be numeric: {parts[1]}"
+
+
+def test_version_matches_pyproject():
+    """Test that __version__ matches pyproject.toml version."""
+    try:
+        import tomllib  # Python 3.11+ standard library
+    except ModuleNotFoundError:
+        import tomli as tomllib  # Python 3.8-3.10 backport (dev dependency)
+    from pathlib import Path
+
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        pyproject = tomllib.load(f)
+
+    pyproject_version = pyproject["project"]["version"]
+    module_version = sfdc.__version__
+
+    assert module_version == pyproject_version, (
+        f"Version mismatch: __init__.__version__ = {module_version}, "
+        f"pyproject.toml version = {pyproject_version}"
+    )

--- a/salesforce_datacloud_connector/tests/test_metadata_pg.py
+++ b/salesforce_datacloud_connector/tests/test_metadata_pg.py
@@ -31,14 +31,29 @@ class TestBuildQueries:
     def test_build_tables_query_with_schema_filter(self):
         """Test building tables query with schema pattern."""
         sql, params = _build_tables_query("public", None, None)
-        assert "n.nspname LIKE :schema_pattern" in sql
+        # v3 speaks positional (qmark) parameters only, so the placeholder must
+        # be ? rather than a :named placeholder.
+        assert "n.nspname LIKE ?" in sql
         assert params["schema_pattern"] == "public"
 
     def test_build_tables_query_with_table_filter(self):
         """Test building tables query with table name pattern."""
         sql, params = _build_tables_query(None, "Account%", None)
-        assert "c.relname LIKE :table_name_pattern" in sql
+        assert "c.relname LIKE ?" in sql
         assert params["table_name_pattern"] == "Account%"
+
+    def test_build_tables_query_uses_positional_placeholders(self):
+        """Regression: the v3 client sends positional (qmark) parameters, so
+        the generated SQL must never contain :named placeholders. A named
+        placeholder here made the live server reject every catalog query with
+        "conflicting parameter style 'named' ... set to 'qmark'"."""
+        sql, params = _build_tables_query("public", "Account%", None)
+        assert ":schema_pattern" not in sql
+        assert ":table_name_pattern" not in sql
+        # One qmark per filter, in insertion order (schema then table) so the
+        # positional array _convert_parameters builds lines up with the SQL.
+        assert sql.count("?") == 2
+        assert list(params.keys()) == ["schema_pattern", "table_name_pattern"]
 
     def test_build_tables_query_with_type_filter(self):
         """Test building tables query with table types."""
@@ -56,10 +71,16 @@ class TestBuildQueries:
     def test_build_columns_query_with_filters(self):
         """Test building columns query with filters."""
         sql, params = _build_columns_query("public", "Account%")
-        assert "n.nspname LIKE :schema_pattern" in sql
-        assert "c.relname LIKE :table_name_pattern" in sql
+        # v3 positional (qmark) parameters, not :named placeholders.
+        assert "n.nspname LIKE ?" in sql
+        assert "c.relname LIKE ?" in sql
+        assert ":schema_pattern" not in sql
+        assert ":table_name_pattern" not in sql
+        assert sql.count("?") == 2
         assert params["schema_pattern"] == "public"
         assert params["table_name_pattern"] == "Account%"
+        # Insertion order must be schema then table to match the positional array.
+        assert list(params.keys()) == ["schema_pattern", "table_name_pattern"]
 
 
 class TestTypeMapping:

--- a/salesforce_datacloud_connector/tests/test_metadata_pg.py
+++ b/salesforce_datacloud_connector/tests/test_metadata_pg.py
@@ -51,7 +51,7 @@ class TestBuildQueries:
         assert ":schema_pattern" not in sql
         assert ":table_name_pattern" not in sql
         # One qmark per filter, in insertion order (schema then table) so the
-        # positional array _convert_parameters builds lines up with the SQL.
+        # positional array _bind_parameters builds lines up with the SQL.
         assert sql.count("?") == 2
         assert list(params.keys()) == ["schema_pattern", "table_name_pattern"]
 

--- a/salesforce_datacloud_connector/tests/test_models.py
+++ b/salesforce_datacloud_connector/tests/test_models.py
@@ -1,6 +1,5 @@
 """Tests for API models."""
 
-import pytest
 
 from salesforce_datacloud_connector.api.models import QueryStatus, ColumnMetadata, QueryResponse
 

--- a/salesforce_datacloud_connector/tests/test_models.py
+++ b/salesforce_datacloud_connector/tests/test_models.py
@@ -1,0 +1,99 @@
+"""Tests for API models."""
+
+import pytest
+
+from salesforce_datacloud_connector.api.models import QueryStatus, ColumnMetadata, QueryResponse
+
+
+def test_query_status_from_dict_normalizes_running_or_unspecified():
+    """Test that RUNNING_OR_UNSPECIFIED is normalized to RUNNING."""
+    data = {
+        "queryId": "MTAuMjQuMTIzLjE5NDo3NDg0_cb6991ab",
+        "completionStatus": "RUNNING_OR_UNSPECIFIED",
+        "progress": 0.5,
+        "rowCount": 0,
+        "chunkCount": 0,
+        "expirationTime": "2025-09-26T10:55:07.438Z",
+        "executionStats": {
+            "wallClockTime": 1.122854338,
+            "rowsProcessed": 5
+        }
+    }
+
+    status = QueryStatus.from_dict(data)
+
+    assert status.completion_status == "RUNNING"
+    assert status.query_id == "MTAuMjQuMTIzLjE5NDo3NDg0_cb6991ab"
+    assert status.progress == 0.5
+    assert not status.is_complete()
+
+
+def test_query_status_recognizes_results_produced():
+    """Test that RESULTS_PRODUCED is recognized as complete."""
+    data = {
+        "queryId": "q123",
+        "completionStatus": "RESULTS_PRODUCED",
+        "progress": 1.0,
+        "rowCount": 5,
+        "chunkCount": 1,
+    }
+
+    status = QueryStatus.from_dict(data)
+
+    assert status.is_complete()
+    assert not status.is_running()
+
+
+def test_query_status_recognizes_finished():
+    """Test that FINISHED is recognized as complete."""
+    data = {
+        "queryId": "q456",
+        "completionStatus": "FINISHED",
+        "progress": 1.0,
+        "rowCount": 10,
+        "chunkCount": 1,
+    }
+
+    status = QueryStatus.from_dict(data)
+
+    assert status.is_complete()
+
+
+def test_column_metadata_from_dict_lowercase_types():
+    """Test that lowercase type names are preserved."""
+    data = {
+        "name": "id__c",
+        "type": "varchar",
+        "nullable": False
+    }
+
+    col = ColumnMetadata.from_dict(data)
+
+    assert col.name == "id__c"
+    assert col.type == "varchar"
+    assert col.nullable is False
+
+
+def test_query_response_from_dict_v3_shape():
+    """Test parsing v3 response shape with metadata.columns wrapper."""
+    data = {
+        "metadata": {
+            "columns": [
+                {"name": "id__c", "type": "varchar", "nullable": False},
+                {"name": "name__c", "type": "varchar", "nullable": True}
+            ]
+        },
+        "data": [
+            ["c1ce2a48-9d03-4eed-938d-f354db79c425", "Gowtham"]
+        ],
+        "returnedRows": 1
+    }
+
+    response = QueryResponse.from_dict(data)
+
+    assert len(response.metadata) == 2
+    assert response.metadata[0].name == "id__c"
+    assert response.metadata[0].type == "varchar"
+    assert len(response.data) == 1
+    assert response.data[0] == ["c1ce2a48-9d03-4eed-938d-f354db79c425", "Gowtham"]
+    assert response.returned_rows == 1

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -3,7 +3,7 @@ Tests for DataCloudTokenExchanger (core token → CDP token exchange).
 """
 
 import time
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 import responses

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -40,13 +40,6 @@ def test_jwt_token_exchange_success():
         status=200,
     )
 
-    # Mock core token revocation
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
-
     # Create JWT authenticator
     with patch("jwt.encode", return_value="mock_jwt"):
         jwt_auth = JWTAuthenticator(
@@ -70,16 +63,16 @@ def test_jwt_token_exchange_success():
         tenant_endpoint = exchanger.get_tenant_endpoint()
         assert tenant_endpoint == "https://tenant123.c360a.salesforce.com"
 
-        # Verify request sequence: JWT auth → exchange → revoke
-        assert len(responses.calls) == 3
+        # Verify request sequence: JWT auth → exchange (no revoke, matches JDBC)
+        assert len(responses.calls) == 2
         assert "/services/oauth2/token" in responses.calls[0].request.url  # Core token
         assert "/services/a360/token" in responses.calls[1].request.url  # Exchange
-        assert "/services/oauth2/revoke" in responses.calls[2].request.url  # Revoke
 
 
 @responses.activate
-def test_cdp_token_caching_with_60s_buffer():
-    """Test that CDP tokens are cached and reused with 60s buffer before expiry."""
+def test_cdp_token_caching_with_no_buffer():
+    """CDP tokens are cached until exact expiry, with no refresh buffer
+    (matches JDBC's DataCloudToken.isAlive(): now <= expiry)."""
     # Mock core token fetch
     responses.add(
         responses.POST,
@@ -101,13 +94,6 @@ def test_cdp_token_caching_with_60s_buffer():
             "expires_in": 150,  # 150 seconds
             "instance_url": "https://tenant123.c360a.salesforce.com",
         },
-        status=200,
-    )
-
-    # Mock core token revocation
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
         status=200,
     )
 
@@ -134,10 +120,17 @@ def test_cdp_token_caching_with_60s_buffer():
         assert cdp_token_2 == "cdp_token_1"
         assert len(responses.calls) == first_call_count  # No additional calls
 
-        # Simulate time passing (100s: past the 60s buffer threshold of 90s = expiry 150s - 60s)
-        with patch("time.time", return_value=time.time() + 100):
-            # Should trigger re-exchange because current_time >= (expiry - 60)
-            # Add mock for second exchange
+        base_time = time.time()
+
+        # 100s in: still well within expiry (150s) — no 60s buffer means this
+        # must still be a cache hit, unlike the old buffered behavior.
+        with patch("time.time", return_value=base_time + 100):
+            cdp_token_3 = exchanger.get_cdp_token()
+            assert cdp_token_3 == "cdp_token_1"
+            assert len(responses.calls) == first_call_count  # Still no additional calls
+
+        # 151s in: past the exact expiry — must re-exchange.
+        with patch("time.time", return_value=base_time + 151):
             responses.add(
                 responses.POST,
                 "https://test.salesforce.com/services/oauth2/token",
@@ -158,15 +151,10 @@ def test_cdp_token_caching_with_60s_buffer():
                 },
                 status=200,
             )
-            responses.add(
-                responses.POST,
-                "https://myorg.my.salesforce.com/services/oauth2/revoke",
-                status=200,
-            )
 
-            cdp_token_3 = exchanger.get_cdp_token()
-            assert cdp_token_3 == "cdp_token_2"  # New token
-            assert len(responses.calls) > first_call_count  # Additional calls made
+            cdp_token_4 = exchanger.get_cdp_token()
+            assert cdp_token_4 == "cdp_token_2"  # New token
+            assert len(responses.calls) == first_call_count + 2  # core fetch + exchange
 
 
 @responses.activate
@@ -193,11 +181,6 @@ def test_cdp_token_invalidation():
         },
         status=200,
     )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
 
     # Mock second exchange
     responses.add(
@@ -218,11 +201,6 @@ def test_cdp_token_invalidation():
             "expires_in": 3600,
             "instance_url": "https://tenant123.c360a.salesforce.com",
         },
-        status=200,
-    )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
         status=200,
     )
 
@@ -247,26 +225,18 @@ def test_cdp_token_invalidation():
         # Invalidate token
         exchanger.invalidate_token()
 
-        # Get token again - should trigger a new CDP exchange.
-        # The first exchange's revoke also invalidated the core authenticator's own
-        # cache, so it re-fetches a core token rather than reusing the revoked one:
-        # core-token fetch + CDP exchange + core-token revoke = 3 additional calls.
+        # Get token again - should trigger a new CDP exchange: core-token fetch
+        # (the core authenticator never caches) + CDP exchange = 2 additional calls.
         cdp_token_2 = exchanger.get_cdp_token()
         assert cdp_token_2 == "cdp_token_2"
-        assert len(responses.calls) == first_call_count + 3  # fetch + exchange + revoke
+        assert len(responses.calls) == first_call_count + 2  # fetch + exchange
 
 
 @responses.activate
-def test_core_token_refetched_after_revoke_on_natural_cdp_expiry():
-    """Regression: a revoked core token must not be reused for the next exchange.
-
-    Core tokens live ~2h, CDP tokens ~1h. Around the 1h mark get_cdp_token() must
-    re-exchange, but the core authenticator's own cache (unaware of the revoke)
-    would still consider its ~2h-old token valid. Without invalidating that cache
-    on revoke, this re-exchange would hand the already-revoked core token back to
-    a360, which fails it with 401. Assert the second exchange actually used a
-    freshly fetched core token, not the revoked one.
-    """
+def test_core_token_refetched_on_natural_cdp_expiry():
+    """The core authenticator never caches (matches JDBC's getOAuthToken()),
+    so every CDP re-exchange — including a natural expiry-driven one — uses a
+    freshly fetched core token rather than reusing an old one."""
     responses.add(
         responses.POST,
         "https://test.salesforce.com/services/oauth2/token",
@@ -287,11 +257,6 @@ def test_core_token_refetched_after_revoke_on_natural_cdp_expiry():
         },
         status=200,
     )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
 
     with patch("jwt.encode", return_value="mock_jwt"):
         jwt_auth = JWTAuthenticator(
@@ -306,13 +271,12 @@ def test_core_token_refetched_after_revoke_on_natural_cdp_expiry():
             dataspace="default",
         )
 
+        base_time = time.time()
         cdp_token_1 = exchanger.get_cdp_token()
         assert cdp_token_1 == "cdp_token_1"
 
-        # Past the CDP token's 60s buffer (expiry 3600s) but well within what the
-        # core authenticator's own cache would consider valid (expiry 7200s) if it
-        # didn't know about the revoke.
-        with patch("time.time", return_value=time.time() + 3600):
+        # Past the CDP token's exact expiry (3600s, no buffer).
+        with patch("time.time", return_value=base_time + 3601):
             responses.add(
                 responses.POST,
                 "https://test.salesforce.com/services/oauth2/token",
@@ -333,11 +297,6 @@ def test_core_token_refetched_after_revoke_on_natural_cdp_expiry():
                 },
                 status=200,
             )
-            responses.add(
-                responses.POST,
-                "https://myorg.my.salesforce.com/services/oauth2/revoke",
-                status=200,
-            )
 
             cdp_token_2 = exchanger.get_cdp_token()
             assert cdp_token_2 == "cdp_token_2"
@@ -345,7 +304,7 @@ def test_core_token_refetched_after_revoke_on_natural_cdp_expiry():
             exchange_calls = [c for c in responses.calls if "/services/a360/token" in c.request.url]
             assert len(exchange_calls) == 2
             # The second exchange must carry the freshly fetched core token, not
-            # the one already revoked after the first exchange.
+            # the one used for the first exchange.
             assert "core_token_2" in exchange_calls[1].request.url
             assert "core_token_1" not in exchange_calls[1].request.url
 
@@ -374,11 +333,6 @@ def test_get_tenant_endpoint_triggers_exchange():
         },
         status=200,
     )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
 
     with patch("jwt.encode", return_value="mock_jwt"):
         jwt_auth = JWTAuthenticator(
@@ -400,7 +354,7 @@ def test_get_tenant_endpoint_triggers_exchange():
         # Verify token was also cached
         cdp_token = exchanger.get_cdp_token()
         assert cdp_token == "cdp_token"
-        assert len(responses.calls) == 3  # Only one exchange happened
+        assert len(responses.calls) == 2  # Only one exchange happened
 
 
 @responses.activate
@@ -514,11 +468,6 @@ def test_dataspace_included_in_exchange_request():
         },
         status=200,
     )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
 
     with patch("jwt.encode", return_value="mock_jwt"):
         jwt_auth = JWTAuthenticator(
@@ -565,11 +514,6 @@ def test_dataspace_omitted_if_none():
             "expires_in": 3600,
             "instance_url": "https://tenant123.c360a.salesforce.com",
         },
-        status=200,
-    )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
         status=200,
     )
 
@@ -629,11 +573,6 @@ def test_tenant_endpoint_schemeless_response_gets_https_prefix():
         },
         status=200,
     )
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
 
     with patch("jwt.encode", return_value="mock_jwt"):
         jwt_auth = JWTAuthenticator(
@@ -680,13 +619,6 @@ def test_client_credentials_token_exchange_success():
         status=200,
     )
 
-    # Mock core token revocation
-    responses.add(
-        responses.POST,
-        "https://myorg.my.salesforce.com/services/oauth2/revoke",
-        status=200,
-    )
-
     from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
 
     # Create client credentials authenticator
@@ -710,9 +642,8 @@ def test_client_credentials_token_exchange_success():
     tenant_endpoint = exchanger.get_tenant_endpoint()
     assert tenant_endpoint == "https://tenant456.c360a.salesforce.com"
 
-    # Verify request sequence: client creds auth → exchange → revoke
-    assert len(responses.calls) == 3
+    # Verify request sequence: client creds auth → exchange (no revoke, matches JDBC)
+    assert len(responses.calls) == 2
     assert "/services/oauth2/token" in responses.calls[0].request.url  # Core token
     assert "grant_type=client_credentials" in responses.calls[0].request.body
     assert "/services/a360/token" in responses.calls[1].request.url  # Exchange
-    assert "/services/oauth2/revoke" in responses.calls[2].request.url  # Revoke

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -504,3 +504,68 @@ def test_import_from_auth_module():
     """Test that DataCloudTokenExchanger can be imported from auth module."""
     from salesforce_datacloud_connector.auth import DataCloudTokenExchanger
     assert DataCloudTokenExchanger is not None
+
+
+@responses.activate
+def test_client_credentials_token_exchange_success():
+    """Test successful core token → CDP token exchange using client credentials authenticator."""
+    # Mock core token fetch (client credentials flow)
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token_client_creds",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token_from_client_creds",
+            "expires_in": 3600,
+            "instance_url": "https://tenant456.c360a.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock core token revocation
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
+
+    # Create client credentials authenticator
+    client_creds_auth = ClientCredentialsAuthenticator(
+        login_url="https://test.salesforce.com",
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+    )
+
+    # Create exchanger
+    exchanger = DataCloudTokenExchanger(
+        core_authenticator=client_creds_auth,
+        dataspace="default",
+    )
+
+    # Get CDP token
+    cdp_token = exchanger.get_cdp_token()
+    assert cdp_token == "cdp_token_from_client_creds"
+
+    # Verify tenant endpoint
+    tenant_endpoint = exchanger.get_tenant_endpoint()
+    assert tenant_endpoint == "https://tenant456.c360a.salesforce.com"
+
+    # Verify request sequence: client creds auth → exchange → revoke
+    assert len(responses.calls) == 3
+    assert "/services/oauth2/token" in responses.calls[0].request.url  # Core token
+    assert "grant_type=client_credentials" in responses.calls[0].request.body
+    assert "/services/a360/token" in responses.calls[1].request.url  # Exchange
+    assert "/services/oauth2/revoke" in responses.calls[2].request.url  # Revoke

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -500,6 +500,59 @@ def test_dataspace_omitted_if_none():
         assert "dataspace=" not in exchange_call.request.url
 
 
+def test_normalize_endpoint_prefixes_and_is_idempotent():
+    """Unit-level: bare host gets https://, existing scheme is preserved."""
+    norm = DataCloudTokenExchanger._normalize_endpoint
+    assert norm("tenant.c360a.salesforce.com") == "https://tenant.c360a.salesforce.com"
+    assert norm("https://tenant.c360a.salesforce.com") == "https://tenant.c360a.salesforce.com"
+    assert norm("http://tenant.c360a.salesforce.com") == "http://tenant.c360a.salesforce.com"
+
+
+@responses.activate
+def test_tenant_endpoint_schemeless_response_gets_https_prefix():
+    """Real orgs return the a360 instance_url as a bare host (no scheme). The
+    exchanger must normalize it to an https:// URL so the off-core query client
+    can build valid request URLs — mirrors on-core v1, which prepends https://
+    at request time. Regression for the live-run 'No scheme supplied' failure."""
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+    # a360 returns a SCHEMELESS host, exactly as the live pc-rnd org does.
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token",
+            "expires_in": 3600,
+            "instance_url": "tenant789.pc-rnd.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+        exchanger = DataCloudTokenExchanger(core_authenticator=jwt_auth, dataspace="default")
+
+        assert exchanger.get_tenant_endpoint() == "https://tenant789.pc-rnd.c360a.salesforce.com"
+
+
 def test_import_from_auth_module():
     """Test that DataCloudTokenExchanger can be imported from auth module."""
     from salesforce_datacloud_connector.auth import DataCloudTokenExchanger

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -498,3 +498,9 @@ def test_dataspace_omitted_if_none():
         # Verify dataspace was NOT included in exchange request
         exchange_call = [c for c in responses.calls if "/services/a360/token" in c.request.url][0]
         assert "dataspace=" not in exchange_call.request.url
+
+
+def test_import_from_auth_module():
+    """Test that DataCloudTokenExchanger can be imported from auth module."""
+    from salesforce_datacloud_connector.auth import DataCloudTokenExchanger
+    assert DataCloudTokenExchanger is not None

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -134,7 +134,7 @@ def test_cdp_token_caching_with_60s_buffer():
         assert cdp_token_2 == "cdp_token_1"
         assert len(responses.calls) == first_call_count  # No additional calls
 
-        # Simulate time passing (100 seconds - within 60s buffer of expiry at 150s)
+        # Simulate time passing (100s: past the 60s buffer threshold of 90s = expiry 150s - 60s)
         with patch("time.time", return_value=time.time() + 100):
             # Should trigger re-exchange because current_time >= (expiry - 60)
             # Add mock for second exchange
@@ -247,12 +247,13 @@ def test_cdp_token_invalidation():
         # Invalidate token
         exchanger.invalidate_token()
 
-        # Get token again - should trigger new exchange
-        # Note: The core authenticator may reuse its cached token, so we only guarantee
-        # that a new CDP exchange happens (exchange + revoke = 2 calls minimum)
+        # Get token again - should trigger a new CDP exchange.
+        # The core authenticator's own token is still cached (expires_in=7200, no time
+        # advance), so it is reused without a second /oauth2/token call. Only the CDP
+        # exchange + core-token revoke fire: exactly 2 additional calls.
         cdp_token_2 = exchanger.get_cdp_token()
         assert cdp_token_2 == "cdp_token_2"
-        assert len(responses.calls) >= first_call_count + 2  # At least exchange + revoke
+        assert len(responses.calls) == first_call_count + 2  # exchange + revoke
 
 
 @responses.activate

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -1,0 +1,499 @@
+"""
+Tests for DataCloudTokenExchanger (core token → CDP token exchange).
+"""
+
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+import responses
+
+from salesforce_datacloud_connector.auth.oauth import JWTAuthenticator
+from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
+from salesforce_datacloud_connector.exceptions import OperationalError
+
+
+@responses.activate
+def test_jwt_token_exchange_success():
+    """Test successful core token → CDP token exchange using JWT authenticator."""
+    # Mock core token fetch (JWT flow)
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token_12345",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token_67890",
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock core token revocation
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    # Create JWT authenticator
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        # Create exchanger
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        # Get CDP token
+        cdp_token = exchanger.get_cdp_token()
+        assert cdp_token == "cdp_token_67890"
+
+        # Verify tenant endpoint
+        tenant_endpoint = exchanger.get_tenant_endpoint()
+        assert tenant_endpoint == "https://tenant123.c360a.salesforce.com"
+
+        # Verify request sequence: JWT auth → exchange → revoke
+        assert len(responses.calls) == 3
+        assert "/services/oauth2/token" in responses.calls[0].request.url  # Core token
+        assert "/services/a360/token" in responses.calls[1].request.url  # Exchange
+        assert "/services/oauth2/revoke" in responses.calls[2].request.url  # Revoke
+
+
+@responses.activate
+def test_cdp_token_caching_with_60s_buffer():
+    """Test that CDP tokens are cached and reused with 60s buffer before expiry."""
+    # Mock core token fetch
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token_1",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token_1",
+            "expires_in": 150,  # 150 seconds
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock core token revocation
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        # First call - should exchange
+        cdp_token_1 = exchanger.get_cdp_token()
+        assert cdp_token_1 == "cdp_token_1"
+        first_call_count = len(responses.calls)
+
+        # Second call immediately - should use cache
+        cdp_token_2 = exchanger.get_cdp_token()
+        assert cdp_token_2 == "cdp_token_1"
+        assert len(responses.calls) == first_call_count  # No additional calls
+
+        # Simulate time passing (100 seconds - within 60s buffer of expiry at 150s)
+        with patch("time.time", return_value=time.time() + 100):
+            # Should trigger re-exchange because current_time >= (expiry - 60)
+            # Add mock for second exchange
+            responses.add(
+                responses.POST,
+                "https://test.salesforce.com/services/oauth2/token",
+                json={
+                    "access_token": "core_token_2",
+                    "expires_in": 7200,
+                    "instance_url": "https://myorg.my.salesforce.com",
+                },
+                status=200,
+            )
+            responses.add(
+                responses.POST,
+                "https://myorg.my.salesforce.com/services/a360/token",
+                json={
+                    "access_token": "cdp_token_2",
+                    "expires_in": 3600,
+                    "instance_url": "https://tenant123.c360a.salesforce.com",
+                },
+                status=200,
+            )
+            responses.add(
+                responses.POST,
+                "https://myorg.my.salesforce.com/services/oauth2/revoke",
+                status=200,
+            )
+
+            cdp_token_3 = exchanger.get_cdp_token()
+            assert cdp_token_3 == "cdp_token_2"  # New token
+            assert len(responses.calls) > first_call_count  # Additional calls made
+
+
+@responses.activate
+def test_cdp_token_invalidation():
+    """Test that invalidate_token forces a new exchange on next call."""
+    # Mock first exchange
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token_1",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token_1",
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    # Mock second exchange
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token_2",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token_2",
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        # Get first token
+        cdp_token_1 = exchanger.get_cdp_token()
+        assert cdp_token_1 == "cdp_token_1"
+        first_call_count = len(responses.calls)
+
+        # Invalidate token
+        exchanger.invalidate_token()
+
+        # Get token again - should trigger new exchange
+        # Note: The core authenticator may reuse its cached token, so we only guarantee
+        # that a new CDP exchange happens (exchange + revoke = 2 calls minimum)
+        cdp_token_2 = exchanger.get_cdp_token()
+        assert cdp_token_2 == "cdp_token_2"
+        assert len(responses.calls) >= first_call_count + 2  # At least exchange + revoke
+
+
+@responses.activate
+def test_get_tenant_endpoint_triggers_exchange():
+    """Test that get_tenant_endpoint triggers exchange if not cached."""
+    # Mock exchange
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token",
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        # Get tenant endpoint first (before getting token)
+        tenant_endpoint = exchanger.get_tenant_endpoint()
+        assert tenant_endpoint == "https://tenant123.c360a.salesforce.com"
+
+        # Verify token was also cached
+        cdp_token = exchanger.get_cdp_token()
+        assert cdp_token == "cdp_token"
+        assert len(responses.calls) == 3  # Only one exchange happened
+
+
+@responses.activate
+def test_cdp_token_exchange_failure():
+    """Test that exchange failure raises OperationalError."""
+    # Mock core token fetch success
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange failure (401 Unauthorized)
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={"error": "invalid_token", "error_description": "Token is invalid"},
+        status=401,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        # Attempt to get CDP token - should raise OperationalError
+        with pytest.raises(OperationalError, match="CDP token exchange failed"):
+            exchanger.get_cdp_token()
+
+
+@responses.activate
+def test_missing_access_token_in_exchange_response():
+    """Test that missing access_token in response raises OperationalError."""
+    # Mock core token fetch
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange with missing access_token
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+            # Missing access_token
+        },
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        with pytest.raises(OperationalError, match="No access_token in CDP token exchange response"):
+            exchanger.get_cdp_token()
+
+
+@responses.activate
+def test_dataspace_included_in_exchange_request():
+    """Test that dataspace is passed to the CDP token exchange endpoint if set."""
+    # Mock core token fetch
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token",
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="my_custom_dataspace",
+        )
+
+        cdp_token = exchanger.get_cdp_token()
+        assert cdp_token == "cdp_token"
+
+        # Verify dataspace was included in exchange request
+        exchange_call = [c for c in responses.calls if "/services/a360/token" in c.request.url][0]
+        assert "dataspace=my_custom_dataspace" in exchange_call.request.url
+
+
+@responses.activate
+def test_dataspace_omitted_if_none():
+    """Test that dataspace is NOT included in exchange request if None."""
+    # Mock core token fetch
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token",
+            "expires_in": 7200,
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+
+    # Mock CDP token exchange
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token",
+            "expires_in": 3600,
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace=None,  # No dataspace
+        )
+
+        cdp_token = exchanger.get_cdp_token()
+        assert cdp_token == "cdp_token"
+
+        # Verify dataspace was NOT included in exchange request
+        exchange_call = [c for c in responses.calls if "/services/a360/token" in c.request.url][0]
+        assert "dataspace=" not in exchange_call.request.url

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -248,12 +248,106 @@ def test_cdp_token_invalidation():
         exchanger.invalidate_token()
 
         # Get token again - should trigger a new CDP exchange.
-        # The core authenticator's own token is still cached (expires_in=7200, no time
-        # advance), so it is reused without a second /oauth2/token call. Only the CDP
-        # exchange + core-token revoke fire: exactly 2 additional calls.
+        # The first exchange's revoke also invalidated the core authenticator's own
+        # cache, so it re-fetches a core token rather than reusing the revoked one:
+        # core-token fetch + CDP exchange + core-token revoke = 3 additional calls.
         cdp_token_2 = exchanger.get_cdp_token()
         assert cdp_token_2 == "cdp_token_2"
-        assert len(responses.calls) == first_call_count + 2  # exchange + revoke
+        assert len(responses.calls) == first_call_count + 3  # fetch + exchange + revoke
+
+
+@responses.activate
+def test_core_token_refetched_after_revoke_on_natural_cdp_expiry():
+    """Regression: a revoked core token must not be reused for the next exchange.
+
+    Core tokens live ~2h, CDP tokens ~1h. Around the 1h mark get_cdp_token() must
+    re-exchange, but the core authenticator's own cache (unaware of the revoke)
+    would still consider its ~2h-old token valid. Without invalidating that cache
+    on revoke, this re-exchange would hand the already-revoked core token back to
+    a360, which fails it with 401. Assert the second exchange actually used a
+    freshly fetched core token, not the revoked one.
+    """
+    responses.add(
+        responses.POST,
+        "https://test.salesforce.com/services/oauth2/token",
+        json={
+            "access_token": "core_token_1",
+            "expires_in": 7200,  # ~2h
+            "instance_url": "https://myorg.my.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/a360/token",
+        json={
+            "access_token": "cdp_token_1",
+            "expires_in": 3600,  # ~1h
+            "instance_url": "https://tenant123.c360a.salesforce.com",
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://myorg.my.salesforce.com/services/oauth2/revoke",
+        status=200,
+    )
+
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+
+        exchanger = DataCloudTokenExchanger(
+            core_authenticator=jwt_auth,
+            dataspace="default",
+        )
+
+        cdp_token_1 = exchanger.get_cdp_token()
+        assert cdp_token_1 == "cdp_token_1"
+
+        # Past the CDP token's 60s buffer (expiry 3600s) but well within what the
+        # core authenticator's own cache would consider valid (expiry 7200s) if it
+        # didn't know about the revoke.
+        with patch("time.time", return_value=time.time() + 3600):
+            responses.add(
+                responses.POST,
+                "https://test.salesforce.com/services/oauth2/token",
+                json={
+                    "access_token": "core_token_2",
+                    "expires_in": 7200,
+                    "instance_url": "https://myorg.my.salesforce.com",
+                },
+                status=200,
+            )
+            responses.add(
+                responses.POST,
+                "https://myorg.my.salesforce.com/services/a360/token",
+                json={
+                    "access_token": "cdp_token_2",
+                    "expires_in": 3600,
+                    "instance_url": "https://tenant123.c360a.salesforce.com",
+                },
+                status=200,
+            )
+            responses.add(
+                responses.POST,
+                "https://myorg.my.salesforce.com/services/oauth2/revoke",
+                status=200,
+            )
+
+            cdp_token_2 = exchanger.get_cdp_token()
+            assert cdp_token_2 == "cdp_token_2"
+
+            exchange_calls = [c for c in responses.calls if "/services/a360/token" in c.request.url]
+            assert len(exchange_calls) == 2
+            # The second exchange must carry the freshly fetched core token, not
+            # the one already revoked after the first exchange.
+            assert "core_token_2" in exchange_calls[1].request.url
+            assert "core_token_1" not in exchange_calls[1].request.url
 
 
 @responses.activate

--- a/salesforce_datacloud_connector/tests/test_types.py
+++ b/salesforce_datacloud_connector/tests/test_types.py
@@ -1,0 +1,153 @@
+"""Tests for the Data Cloud type system (types.py).
+
+Focus: the off-core Query v3 API returns LOWERCASE type names, while the
+Postgres metadata catalog emits CAPITALIZED names. Both must convert and map
+identically (Finding C).
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from salesforce_datacloud_connector.types import (
+    DATETIME,
+    NUMBER,
+    STRING,
+    build_description_tuple,
+    convert_datacloud_value,
+)
+
+
+class TestConvertLowercaseV3Types:
+    """v3 wire sends lowercase type names — the primary Finding C path."""
+
+    def test_varchar(self):
+        assert convert_datacloud_value("hello", "varchar") == "hello"
+        assert isinstance(convert_datacloud_value("hello", "varchar"), str)
+
+    def test_numeric_scale_zero_is_int(self):
+        result = convert_datacloud_value("42", "numeric", scale=0)
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_numeric_low_precision_is_float(self):
+        result = convert_datacloud_value("3.14", "numeric", precision=10, scale=2)
+        assert result == pytest.approx(3.14)
+        assert isinstance(result, float)
+
+    def test_numeric_high_precision_is_decimal(self):
+        result = convert_datacloud_value("123.456789", "numeric", precision=20, scale=6)
+        assert result == Decimal("123.456789")
+        assert isinstance(result, Decimal)
+
+    def test_integer_and_bigint_are_int(self):
+        assert convert_datacloud_value("7", "integer") == 7
+        assert isinstance(convert_datacloud_value("7", "integer"), int)
+        assert convert_datacloud_value("9000000000", "bigint") == 9000000000
+        assert isinstance(convert_datacloud_value("9000000000", "bigint"), int)
+
+    def test_float_and_double_are_float(self):
+        assert convert_datacloud_value("1.5", "float") == pytest.approx(1.5)
+        assert isinstance(convert_datacloud_value("1.5", "float"), float)
+        assert convert_datacloud_value("2.25", "double") == pytest.approx(2.25)
+        assert isinstance(convert_datacloud_value("2.25", "double"), float)
+
+    def test_timestamptz_is_tzaware_datetime(self):
+        result = convert_datacloud_value("2024-01-15T10:30:00+00:00", "timestamptz")
+        assert isinstance(result, datetime)
+        assert result.tzinfo is not None
+
+    def test_date_is_date(self):
+        result = convert_datacloud_value("2024-01-15", "date")
+        assert result == date(2024, 1, 15)
+        assert isinstance(result, date)
+
+    def test_boolean_from_strings(self):
+        assert convert_datacloud_value("true", "boolean") is True
+        assert convert_datacloud_value("false", "boolean") is False
+        assert convert_datacloud_value("t", "boolean") is True
+        assert convert_datacloud_value("no", "boolean") is False
+
+    def test_boolean_from_bool(self):
+        assert convert_datacloud_value(True, "boolean") is True
+        assert convert_datacloud_value(False, "boolean") is False
+
+    def test_text_is_str(self):
+        assert convert_datacloud_value(123, "text") == "123"
+        assert isinstance(convert_datacloud_value(123, "text"), str)
+
+
+class TestConvertCapitalizedTypesRegression:
+    """PG catalog / canonical names are capitalized — must still convert (no regression)."""
+
+    def test_capitalized_varchar(self):
+        assert convert_datacloud_value("hello", "Varchar") == "hello"
+
+    def test_capitalized_numeric_scale_zero(self):
+        result = convert_datacloud_value("42", "Numeric", scale=0)
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_capitalized_timestamptz(self):
+        result = convert_datacloud_value("2024-01-15T10:30:00+00:00", "TimestampTZ")
+        assert isinstance(result, datetime)
+        assert result.tzinfo is not None
+
+    def test_capitalized_date(self):
+        assert convert_datacloud_value("2024-01-15", "Date") == date(2024, 1, 15)
+
+    def test_capitalized_boolean(self):
+        assert convert_datacloud_value("true", "Boolean") is True
+
+    def test_capitalized_integer(self):
+        assert convert_datacloud_value("7", "Integer") == 7
+
+
+class TestConvertEdgeCases:
+    def test_null_returns_none_regardless_of_type(self):
+        assert convert_datacloud_value(None, "numeric") is None
+        assert convert_datacloud_value(None, "Varchar") is None
+        assert convert_datacloud_value(None, "timestamptz") is None
+
+    def test_unknown_type_returns_value_as_is(self):
+        sentinel = object()
+        assert convert_datacloud_value(sentinel, "geography") is sentinel
+
+    def test_invalid_numeric_raises_valueerror_with_original_type_name(self):
+        with pytest.raises(ValueError, match="numeric"):
+            convert_datacloud_value("not-a-number", "numeric", scale=0)
+
+
+class TestBuildDescriptionTuple:
+    """type_code lookup must be case-insensitive for both wire shapes."""
+
+    def test_lowercase_numeric_maps_to_number(self):
+        desc = build_description_tuple({"name": "age", "type": "numeric", "scale": 0})
+        assert desc[0] == "age"
+        assert desc[1] == NUMBER
+
+    def test_lowercase_timestamptz_maps_to_datetime(self):
+        desc = build_description_tuple({"name": "created", "type": "timestamptz"})
+        assert desc[1] == DATETIME
+
+    def test_lowercase_varchar_maps_to_string(self):
+        desc = build_description_tuple({"name": "label", "type": "varchar"})
+        assert desc[1] == STRING
+
+    def test_capitalized_numeric_still_maps_to_number(self):
+        desc = build_description_tuple({"name": "age", "type": "Numeric", "scale": 0})
+        assert desc[1] == NUMBER
+
+    def test_unknown_type_defaults_to_string(self):
+        desc = build_description_tuple({"name": "mystery", "type": "geography"})
+        assert desc[1] == STRING
+
+    def test_nullable_and_precision_passthrough(self):
+        desc = build_description_tuple(
+            {"name": "amount", "type": "numeric", "nullable": False, "precision": 18, "scale": 2}
+        )
+        # (name, type_code, display_size, internal_size, precision, scale, null_ok)
+        assert desc[4] == 18
+        assert desc[5] == 2
+        assert desc[6] is False

--- a/salesforce_datacloud_connector/uv.lock
+++ b/salesforce_datacloud_connector/uv.lock
@@ -1966,6 +1966,7 @@ dev = [
     { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-cov", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pyyaml" },
     { name = "responses" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1986,6 +1987,7 @@ provides-extras = ["pandas"]
 dev = [
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "responses", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },

--- a/salesforce_datacloud_connector/uv.lock
+++ b/salesforce_datacloud_connector/uv.lock
@@ -1936,7 +1936,7 @@ wheels = [
 
 [[package]]
 name = "salesforce-datacloud-connector"
-version = "2.0.0b1"
+version = "2.0.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography", version = "47.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version <= '3.9'" },
@@ -1968,6 +1968,7 @@ dev = [
     { name = "pytest-cov", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -1987,6 +1988,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "responses", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Re-platforms the **`salesforce_datacloud_connector` v2 (Python)** query path from the on-core Connect API onto the **off-core HTTP Query v3 REST endpoint** (`POST /api/v3/query`). The driver keeps its DB-API 2.0 (PEP 249) surface — `connect()` / `Connection` / `Cursor`, `paramstyle="named"` — so existing user code is unchanged; only the transport and auth composition underneath are new.

Version bumps `2.0.0b1 → 2.0.0b2`.

## Why

The off-core v3 REST API is the supported path for external query clients. It moves query status into a response header (`x-hyperdb-status`), returns lowercase column type names, paginates rows via `/query/{id}/rows`, and requires a core→Data Cloud token exchange rather than a direct on-core call.

## What changed

**Auth composition (off-core)**
- New `DataCloudTokenExchanger` — exchanges a core auth token for a Data Cloud token via `/services/a360/token`.
- New `ClientCredentialsAuthenticator` (OAuth 2.0 client-credentials flow), joining the existing JWT / refresh-token / username-password flows.
- `connect()` now composes: core authenticator → `DataCloudTokenExchanger` → `Connection` → `DataCloudQueryClient` (v3).

**Query v3 transport (`api/client.py`)**
- `execute_query` → `POST /api/v3/query`; reads query status from the `x-hyperdb-status` **response header** (the v3 body carries no status), with a guard that raises `OperationalError` if the header is missing.
- `get_query_status` → `GET /api/v3/query/{id}` (header-parsed).
- `fetch_results` → `GET /api/v3/query/{id}/rows` with `offset` / `limit` / `byteLimit` pagination.
- `cancel_query` → `DELETE /api/v3/query/{id}`.
- Headers: `ctx-dataspace-ds_name`, `x-hyperdb-workload`.

**Parameter binding**
- v3 accepts **positional (qmark) parameters only**. The driver still advertises `paramstyle="named"`, so `_bind_parameters` rewrites `:name` placeholders to `?` in SQL order (a name reused N times expands to N qmarks + N values), preserves PostgreSQL `::type` casts, passes qmark-style SQL through untouched, and raises `ProgrammingError` for a missing named value.

**Type mapping**
- v3 returns **lowercase** column type names (`varchar`, `numeric`, `timestamptz`, …). Type conversion and `cursor.description` are now case-insensitive, so numeric/boolean/date/timestamp values coerce correctly (Decimal, tz-aware datetime, bool) instead of falling through as raw strings. The internal `pg_catalog` metadata path (which emits capitalized Data Cloud names) still works — the lookup is case-insensitive, not lowercase-only.

**Query status accessor**
- `cursor.get_query_status()` — a non-blocking accessor returning the most recently observed `QueryStatus` for the cursor's query (refreshed on `execute()` and after the async polling loop; issues no extra HTTP call). `QueryStatus` is now exported at the top level as `sfdc.QueryStatus`. In off-core v3 the status originates from the `x-hyperdb-status` response header and exposes `query_id`, `completion_status`, `progress`, `row_count`, `chunk_count`, `expiration_time`.

**CI / deps**
- Dependabot config for the dual v1/v2 tree; PyYAML + `tomli`/`tomllib` dev deps; CI-config validation tests.

## Testing

- **Unit suite: 162 passed / 3 skipped** (`pytest -m "not e2e"`), ruff clean (line-length 120). New/updated tests cover the token exchanger, client-credentials flow, v3 request/response shape, header-based status parsing, `/rows` pagination, named→positional parameter translation, lowercase type mapping, and the `get_query_status()` cursor accessor + `QueryStatus.from_dict` parsing.
- **Live validation** against a live Data Cloud tenant: the end-to-end sample harness passes, including `SELECT` with correct type conversion (Decimal, tz-aware datetime), `COUNT(*)`, and table-metadata retrieval. Three integration bugs surfaced by the live run were fixed here:
  - schemeless `a360` tenant host → normalize to `https://` at capture;
  - `pg_catalog` metadata queries used `:named` placeholders → switched to `?`;
  - the general named-parameter case above (`:name` left in SQL while sending a positional array).

## Known limitations (not addressed in this PR)

- **Integer equality-bind parameter** — the tenant rejects an integer bind with sqlState 22023; pre-existing and orthogonal to the transport migration (tracked as a known issue / xfail in the sample).

## Notes

- All commits are SSH-signed.
- No production behavior change to the DB-API surface — existing `:name` query code continues to work.
