### PR TITLE
chore(codeowners): Set valid GUSINFO in CODEOWNERS (OSPO compliance)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:CDP Query Service (US),D360 Query - Immutable


### PR DESCRIPTION
Point the CODEOWNERS #GUSINFO line at the repo's owning GUS Scrum Team and Product Tag, per OSPO policy. Both records are Active in GUS.

Scrum Team:  CDP Query Service (US)
Product Tag: D360 Query - Immutable