### PR TITLE
@W-24004706 Report actual cursor.rowcount from server query status

### DIFF
--- a/salesforce_datacloud_connector/CHANGELOG.md
+++ b/salesforce_datacloud_connector/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `cursor.rowcount` now reports the total number of rows in the result set
+  after `execute()`, as read from the server's query status, instead of always
+  returning `-1`. It remains `-1` before any query is executed and is reset to
+  `-1` at the start of each `execute()` so a failed execution does not report a
+  stale count (DB-API 2.0 / PEP 249).
+
 ## 2.0.0b1 — Beta release (TBD)
 
 First public beta of the new `salesforce-datacloud-connector` package, the

--- a/salesforce_datacloud_connector/README.md
+++ b/salesforce_datacloud_connector/README.md
@@ -326,7 +326,8 @@ This connector follows
 #### Cursor attributes
 
 - `description` — column metadata.
-- `rowcount` — number of rows affected (`-1` for SELECT until exhausted).
+- `rowcount` — total rows in the result set, reported by the server after
+  `execute()` (`-1` before any query is executed).
 - `arraysize` — default fetch size for `fetchmany()`.
 
 ### Exception hierarchy

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/cursor.py
@@ -38,7 +38,7 @@ class Cursor:
         self._total_row_count: int = 0  # Total rows in result set
         self._fetched_rows: int = 0  # Total rows fetched from server
         self._description: Optional[List[Tuple]] = None
-        self._rowcount: int = -1  # DB-API 2.0: -1 for SELECT, else number of rows affected
+        self._rowcount: int = -1
         self._closed: bool = False
         # Latest QueryStatus observed on this cursor — refreshed by execute()
         # and by the polling loop. Returned by get_query_status() without an
@@ -61,13 +61,8 @@ class Cursor:
     @property
     def rowcount(self) -> int:
         """
-        DB-API 2.0 cursor.rowcount attribute.
-
-        For SELECT queries, returns -1 (per DB-API 2.0 spec).
-        For DML queries (not supported in V1), would return affected rows.
-
-        Returns:
-            -1 for SELECT queries
+        Total rows in the result set after execute(), or -1 before any query
+        has been executed (DB-API 2.0).
         """
         return self._rowcount
 
@@ -162,6 +157,8 @@ class Cursor:
         """
         self._check_closed()
 
+        self._rowcount = -1
+
         # Check for unsupported operations (V1 is read-only)
         operation_upper = operation.strip().upper()
         if any(
@@ -180,7 +177,6 @@ class Cursor:
         self._metadata = response.metadata
         self._total_row_count = response.status.row_count
         self._query_status = response.status
-        self._rowcount = -1  # SELECT queries return -1
         self._build_description()
 
         # Handle sync vs async responses
@@ -197,6 +193,8 @@ class Cursor:
 
             # Fetch first chunk
             self._fetch_next_chunk()
+
+        self._rowcount = self._total_row_count
 
         return self
 

--- a/salesforce_datacloud_connector/tests/test_cursor.py
+++ b/salesforce_datacloud_connector/tests/test_cursor.py
@@ -25,10 +25,179 @@ def test_cursor_description_before_execute():
     assert cursor.description is None
 
 
-def test_cursor_rowcount():
-    """Test that rowcount returns -1 for SELECT queries."""
+def test_cursor_rowcount_before_execute():
+    """Before any execute(), rowcount is -1 per DB-API 2.0."""
     client = create_mock_client()
     cursor = Cursor(client)
+
+    assert cursor.rowcount == -1
+
+
+def test_rowcount_after_sync_execute():
+    """After a synchronous execute(), rowcount reports the server row count."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[["Alice", 30], ["Bob", 25]],
+        metadata=[
+            ColumnMetadata(name="name", type="Varchar"),
+            ColumnMetadata(name="age", type="Numeric", scale=0),
+        ],
+        returned_rows=2,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=2,
+            chunk_count=1,
+        ),
+    )
+
+    cursor.execute("SELECT name, age FROM users")
+
+    assert cursor.rowcount == 2
+
+
+def test_rowcount_after_async_execute():
+    """After an async execute(), rowcount reflects the final polled row count."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="Running",
+            progress=0.5,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+    client.poll_until_complete.return_value = QueryStatus(
+        query_id="q1",
+        completion_status="Finished",
+        progress=1.0,
+        row_count=100,
+        chunk_count=1,
+    )
+    client.fetch_results.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[],
+        returned_rows=2,
+    )
+
+    cursor.execute("SELECT name FROM large_table")
+
+    assert cursor.rowcount == 100
+
+
+def test_rowcount_empty_result():
+    """A query that produces zero rows reports rowcount 0, not -1."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=0,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=0,
+            chunk_count=0,
+        ),
+    )
+
+    cursor.execute("SELECT name FROM users WHERE 1=0")
+
+    assert cursor.rowcount == 0
+
+
+def test_rowcount_matches_total_across_pagination():
+    """rowcount is the full total up front, even before paginated chunks are fetched."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[["Row1"], ["Row2"]],
+        metadata=[ColumnMetadata(name="data", type="Varchar")],
+        returned_rows=2,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=4,
+            chunk_count=2,
+        ),
+    )
+    client.fetch_results.return_value = QueryResponse(
+        data=[["Row3"], ["Row4"]],
+        metadata=[],
+        returned_rows=2,
+    )
+
+    cursor.execute("SELECT data FROM table")
+
+    assert cursor.rowcount == 4
+    assert len(cursor.fetchall()) == 4
+    assert cursor.rowcount == 4
+
+
+def test_rowcount_reset_after_failed_reexecute_dml_guard():
+    """A failed re-execute (DML guard) resets rowcount to -1, not the prior total."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[["Alice"], ["Bob"]],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=2,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=5,
+            chunk_count=1,
+        ),
+    )
+
+    cursor.execute("SELECT name FROM users")
+    assert cursor.rowcount == 5
+
+    with pytest.raises(NotSupportedError):
+        cursor.execute("INSERT INTO users VALUES (1, 'x')")
+
+    assert cursor.rowcount == -1
+
+
+def test_rowcount_reset_after_failed_reexecute_server_error():
+    """A failed re-execute (execute_query raising) resets rowcount to -1."""
+    client = create_mock_client()
+    cursor = Cursor(client)
+
+    client.execute_query.return_value = QueryResponse(
+        data=[["Alice"]],
+        metadata=[ColumnMetadata(name="name", type="Varchar")],
+        returned_rows=1,
+        status=QueryStatus(
+            query_id="q1",
+            completion_status="ResultsProduced",
+            progress=1.0,
+            row_count=1,
+            chunk_count=1,
+        ),
+    )
+
+    cursor.execute("SELECT name FROM users")
+    assert cursor.rowcount == 1
+
+    client.execute_query.side_effect = InterfaceError("boom")
+    with pytest.raises(InterfaceError):
+        cursor.execute("SELECT bad syntax")
 
     assert cursor.rowcount == -1
 


### PR DESCRIPTION
## Summary

`cursor.rowcount` previously always returned `-1`, regardless of the query. This
PR makes it report the **actual total number of rows in the result set** after
`execute()`, read from the server's query status — the same row count the cursor
already trusts to drive pagination.

Behavior now conforms to [PEP 249 / DB-API 2.0](https://peps.python.org/pep-0249/#rowcount):

- **Before any query** is executed → `-1` (unchanged).
- **After a successful `execute()`** → total rows in the result set, for both
  synchronous responses and polled asynchronous queries.
- **Reset to `-1` at the start of every `execute()`**, so a failed
  re-execution reports `-1` rather than a stale count from the previous query.

## Motivation

`@W-24004706`

A hard-coded `rowcount` of `-1` is technically DB-API-legal ("unknown"), but it
breaks the common idiom of checking `cursor.rowcount` after a query and forces
callers to `len(fetchall())` — materializing the whole result set — just to
learn the row count the server already reported.

## Changes

- **`cursor.py`**
  - `rowcount` now returns the finalized total row count captured at the end of
    `execute()` (populated from `response.status.row_count` for sync, and from
    the post-poll `final_status.row_count` for async).
  - `_rowcount` is reset to `-1` up front in `execute()` so a failed execute
    (DML/DDL guard or a server error) does not leave a stale count.
- **`tests/test_cursor.py`** — added regression coverage:
  - `test_cursor_rowcount_before_execute` — `-1` before any `execute()`.
  - `test_rowcount_after_sync_execute` — sync result → exact count.
  - `test_rowcount_after_async_execute` — running → polled → final count.
  - `test_rowcount_empty_result` — `0`, not `-1`, for empty results.
  - `test_rowcount_matches_total_across_pagination` — stable before and after
    `fetchall()` across multiple chunks.
  - `test_rowcount_reset_after_failed_reexecute_dml_guard` /
    `..._server_error` — resets to `-1` when a second `execute()` raises.
- **`README.md`** — updated the `rowcount` attribute description.
- **`CHANGELOG.md`** — added an `Unreleased` entry.

## Alignment with the JDBC driver

Cross-checked against the sibling
[`forcedotcom/datacloud-jdbc`](https://github.com/forcedotcom/datacloud-jdbc)
driver: the true result-set row count is carried in `QueryStatus.rowCount`,
the same status field this change reads. The approach is consistent with the
sibling driver's model of the query status.

## Testing

```
uv run pytest -m "not e2e"   # 167 passed, 3 skipped
uv run ruff check salesforce_datacloud_connector tests   # All checks passed!
```

Each new test was verified to fail against the pre-fix (buggy) implementation,
so they exercise the behavior rather than tautologically passing.
