### PR TITLE
feat(auth): add Salesforce CLI authenticator for local/dev

### DIFF
--- a/salesforce_datacloud_connector/CHANGELOG.md
+++ b/salesforce_datacloud_connector/CHANGELOG.md
@@ -23,10 +23,14 @@ install with `pip install --pre salesforce-datacloud-connector`.
 ### Added
 - DB-API 2.0 compliant driver targeting the Salesforce Data Cloud Query API
   (V3 driver path).
-- Three OAuth authentication flows:
+- Four OAuth authentication flows:
   - Username/Password (`UsernamePasswordAuthenticator`)
   - JWT Bearer Token (`JWTAuthenticator`)
   - Refresh Token (`RefreshTokenAuthenticator`)
+  - Client Credentials (`ClientCredentialsAuthenticator`)
+- Salesforce CLI authenticator (`SfCliAuthenticator`, `auth_type="sf_cli"`) for
+  local/dev — reuses the org the `sf` CLI is already authenticated against
+  instead of requiring a connected app.
 - Connection-level support for `dataspace` and `workload`.
 - Cursor surface: `execute`, `executemany`, `fetchone`, `fetchmany`,
   `fetchall`, iteration, `description`, `rowcount`, `arraysize`, and `cancel`.

--- a/salesforce_datacloud_connector/README.md
+++ b/salesforce_datacloud_connector/README.md
@@ -40,7 +40,7 @@ still in beta to allow for adjustments based on field feedback.
 ## Features
 
 - **DB-API 2.0 compliant** — standard Python database interface.
-- **Four OAuth flows** — JWT Bearer Token, Refresh Token, Client Credentials, Username/Password.
+- **Five auth flows** — JWT Bearer Token, Refresh Token, Client Credentials, Username/Password, and Salesforce CLI (local/dev).
 - **Pandas integration** — works with `pandas.read_sql()` and
   `cursor.fetch_df()` (under the `[pandas]` extra).
 - **Notebook-ready** — interactive exploration and visualization in Jupyter.
@@ -119,7 +119,7 @@ with sfdc.connect(...) as conn:
 
 ## Authentication
 
-The connector ships four OAuth flows, all driven through `sfdc.connect(...)`
+The connector ships five auth flows, all driven through `sfdc.connect(...)`
 via the `auth_type` keyword.
 
 ### JWT Bearer Token (recommended)
@@ -184,6 +184,36 @@ conn = sfdc.connect(
     client_secret=os.environ["SFDC_CLIENT_SECRET"],
 )
 ```
+
+### Salesforce CLI (recommended for local/dev)
+
+The `sf_cli` flow reuses whatever org the [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli)
+is already authenticated against — no connected app, client secret, or JWT
+key required. It's the fastest way to point the connector at an org during
+local development:
+
+```bash
+sf org login web --alias my-org --scopes "api cdpquery refresh_token offline_access"
+```
+
+The `--scopes` flag matters: without it, the CLI's session may not carry the
+`cdpquery` scope, and the Data Cloud token exchange fails with
+`invalid_scope`. If it does, re-run `sf org login web` with `--scopes` as
+shown above (add `--instance-url` for sandboxes or non-default pods).
+
+```python
+import salesforce_datacloud_connector as sfdc
+
+conn = sfdc.connect(
+    auth_type="sf_cli",
+    target_org="my-org",  # alias or username; omit to use the CLI's default org
+)
+```
+
+Each call to `sfdc.connect(...)` shells out to `sf org display` and
+`sf org auth show-access-token` to fetch a fresh token — the CLI handles its
+own token refresh, so there's nothing to configure or rotate. Requires the
+`sf` executable to be on `PATH`.
 
 ### Username/Password (deprecated)
 

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -80,9 +80,9 @@ def connect(
     client_secret: Optional[str] = None,
     jwt_private_key: Optional[str] = None,
     refresh_token: Optional[str] = None,
-    target_org: Optional[str] = None,
     dataspace: Optional[str] = None,
     workload: Optional[str] = None,
+    target_org: Optional[str] = None,
 ) -> Connection:
     """
     Create a connection to Salesforce Data Cloud.
@@ -102,10 +102,10 @@ def connect(
         client_secret: Connected app client secret (required for username_password and refresh_token)
         jwt_private_key: Private key in PEM format for JWT flow (required for jwt)
         refresh_token: OAuth refresh token (required for refresh_token)
-        target_org: Org alias or username for the sf_cli auth type. If omitted,
-                    the Salesforce CLI's own default org is used.
         dataspace: Data space name (default: "default")
         workload: Optional workload name for logging/debugging
+        target_org: Org alias or username for the sf_cli auth type. If omitted,
+                    the Salesforce CLI's own default org is used.
 
     Returns:
         Connection instance

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -63,6 +63,7 @@ from .auth.oauth import (
     ClientCredentialsAuthenticator,
     JWTAuthenticator,
     RefreshTokenAuthenticator,
+    SfCliAuthenticator,
     UsernamePasswordAuthenticator,
 )
 
@@ -79,6 +80,7 @@ def connect(
     client_secret: Optional[str] = None,
     jwt_private_key: Optional[str] = None,
     refresh_token: Optional[str] = None,
+    target_org: Optional[str] = None,
     dataspace: Optional[str] = None,
     workload: Optional[str] = None,
 ) -> Connection:
@@ -92,13 +94,16 @@ def connect(
     Args:
         login_url: Salesforce login URL (default: "https://login.salesforce.com")
                   Use "https://test.salesforce.com" for sandboxes
-        auth_type: Authentication type - "username_password", "jwt", "refresh_token", or "client_credentials"
+        auth_type: Authentication type - "username_password", "jwt", "refresh_token",
+                   "client_credentials", or "sf_cli"
         username: Salesforce username (required for username_password and jwt)
         password: Salesforce password (required for username_password)
-        client_id: Connected app client ID (required for all auth types)
+        client_id: Connected app client ID (required for all auth types except sf_cli)
         client_secret: Connected app client secret (required for username_password and refresh_token)
         jwt_private_key: Private key in PEM format for JWT flow (required for jwt)
         refresh_token: OAuth refresh token (required for refresh_token)
+        target_org: Org alias or username for the sf_cli auth type. If omitted,
+                    the Salesforce CLI's own default org is used.
         dataspace: Data space name (default: "default")
         workload: Optional workload name for logging/debugging
 
@@ -185,10 +190,13 @@ def connect(
             client_secret=client_secret,
         )
 
+    elif auth_type == "sf_cli":
+        authenticator = SfCliAuthenticator(target_org=target_org)
+
     else:
         raise ValueError(
             f"Invalid auth_type: {auth_type}. "
-            f"Must be 'username_password', 'jwt', 'refresh_token', or 'client_credentials'"
+            f"Must be 'username_password', 'jwt', 'refresh_token', 'client_credentials', or 'sf_cli'"
         )
 
     # Wrap authenticator in token exchanger for CDP token + tenant endpoint
@@ -237,6 +245,7 @@ __all__ = [
     "JWTAuthenticator",
     "RefreshTokenAuthenticator",
     "ClientCredentialsAuthenticator",
+    "SfCliAuthenticator",
     "DataCloudTokenExchanger",
 ]
 

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/__init__.py
@@ -5,6 +5,7 @@ from .oauth import (
     JWTAuthenticator,
     OAuthAuthenticator,
     RefreshTokenAuthenticator,
+    SfCliAuthenticator,
     UsernamePasswordAuthenticator,
 )
 from .token_exchanger import DataCloudTokenExchanger
@@ -15,5 +16,6 @@ __all__ = [
     "JWTAuthenticator",
     "RefreshTokenAuthenticator",
     "ClientCredentialsAuthenticator",
+    "SfCliAuthenticator",
     "DataCloudTokenExchanger",
 ]

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
@@ -12,6 +12,9 @@ the JDBC driver's DataCloudTokenProvider.
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import time
 from abc import ABC, abstractmethod
 from typing import Optional
@@ -371,3 +374,82 @@ class ClientCredentialsAuthenticator(OAuthAuthenticator):
             raise OperationalError(
                 f"Authentication failed with client credentials: {e}"
             ) from e
+
+
+class SfCliAuthenticator(OAuthAuthenticator):
+    """
+    Authenticates using the locally installed Salesforce CLI (`sf`).
+
+    Intended for local development: reuses whatever org the Salesforce CLI is
+    already authenticated against (e.g. via `sf org login web`) instead of
+    requiring a connected app's client_id/secret or a JWT key. Every call
+    re-invokes the CLI, which transparently refreshes its own stored token if
+    needed — this matches the no-cache model of the other authenticators.
+
+    Recent CLI versions redact `accessToken` from `sf org display` output, so
+    the token and instance URL are fetched from two separate subcommands.
+    """
+
+    def __init__(self, target_org: Optional[str] = None, cli_path: str = "sf"):
+        """
+        Initialize the Salesforce CLI authenticator.
+
+        Args:
+            target_org: Org alias or username to pass as `--target-org` to
+                        the CLI. If omitted, the CLI's own default org applies.
+            cli_path: Path to the Salesforce CLI executable (default: "sf")
+        """
+        super().__init__()
+        self.target_org = target_org
+        self.cli_path = cli_path
+
+    def _run_sf(self, *args: str) -> dict:
+        """Run an `sf` subcommand with --json and return its parsed payload."""
+        command = [self.cli_path, *args, "--json"]
+        if self.target_org:
+            command += ["--target-org", self.target_org]
+
+        # --json output must stay plain: if the caller's shell forces color
+        # (e.g. FORCE_COLOR set), the CLI emits ANSI codes even with --json,
+        # which breaks JSON parsing. NO_COLOR overrides that.
+        env = {**os.environ, "NO_COLOR": "1"}
+
+        try:
+            result = subprocess.run(
+                command, capture_output=True, text=True, timeout=30, env=env
+            )
+        except FileNotFoundError as e:
+            raise OperationalError(
+                f"Salesforce CLI ('{self.cli_path}') not found. Install it from "
+                "https://developer.salesforce.com/tools/salesforcecli and authenticate "
+                "with `sf org login web` before using SfCliAuthenticator."
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise OperationalError(f"Salesforce CLI command timed out: {' '.join(command)}") from e
+
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            raise OperationalError(
+                f"Could not parse output of `{' '.join(command)}`: {e}"
+            ) from e
+
+        if payload.get("status") != 0:
+            message = payload.get("message", "Unknown error from Salesforce CLI")
+            raise OperationalError(f"Salesforce CLI authentication failed: {message}")
+
+        return payload.get("result", {})
+
+    def _fetch_new_token(self) -> tuple[str, int, str]:
+        """Fetch a core token and instance URL via the Salesforce CLI."""
+        org_info = self._run_sf("org", "display")
+        instance_url = org_info.get("instanceUrl")
+        if not instance_url:
+            raise OperationalError("No instanceUrl in `sf org display` output")
+
+        token_info = self._run_sf("org", "auth", "show-access-token")
+        access_token = token_info.get("accessToken")
+        if not access_token:
+            raise OperationalError("No accessToken in `sf org auth show-access-token` output")
+
+        return access_token, 7200, instance_url

--- a/salesforce_datacloud_connector/tests/test_auth.py
+++ b/salesforce_datacloud_connector/tests/test_auth.py
@@ -2,6 +2,7 @@
 Tests for OAuth authentication.
 """
 
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ import responses
 from salesforce_datacloud_connector.auth.oauth import (
     JWTAuthenticator,
     RefreshTokenAuthenticator,
+    SfCliAuthenticator,
     UsernamePasswordAuthenticator,
 )
 from salesforce_datacloud_connector.exceptions import OperationalError
@@ -301,3 +303,149 @@ def test_client_credentials_auth_failure():
 
     with pytest.raises(OperationalError):
         auth.get_oauth_token()
+
+
+def _completed_process(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+_ORG_DISPLAY_OK = '{"status": 0, "result": {"instanceUrl": "https://myorg.my.salesforce.com"}}'
+_SHOW_TOKEN_OK = '{"status": 0, "result": {"accessToken": "sf_cli_token_12345"}}'
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_forces_no_color(mock_run):
+    """`sf ... --json` can still emit ANSI color codes when FORCE_COLOR is set
+    in the environment, which breaks JSON parsing. NO_COLOR=1 must be passed
+    to the subprocess env so --json output stays plain regardless of the
+    caller's shell settings."""
+    mock_run.side_effect = [
+        _completed_process(_ORG_DISPLAY_OK),
+        _completed_process(_SHOW_TOKEN_OK),
+    ]
+
+    SfCliAuthenticator().get_oauth_token()
+
+    for call in mock_run.call_args_list:
+        assert call.kwargs["env"]["NO_COLOR"] == "1"
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_success(mock_run):
+    """SfCliAuthenticator combines `org display` (instanceUrl) and
+    `org auth show-access-token` (accessToken) into one core token."""
+    mock_run.side_effect = [
+        _completed_process(_ORG_DISPLAY_OK),
+        _completed_process(_SHOW_TOKEN_OK),
+    ]
+
+    auth = SfCliAuthenticator(target_org="my-alias")
+    token = auth.get_oauth_token()
+
+    assert token == "sf_cli_token_12345"
+    assert auth.get_instance_url() == "https://myorg.my.salesforce.com"
+
+    first_call_args = mock_run.call_args_list[0].args[0]
+    second_call_args = mock_run.call_args_list[1].args[0]
+    assert first_call_args == ["sf", "org", "display", "--json", "--target-org", "my-alias"]
+    assert second_call_args == [
+        "sf", "org", "auth", "show-access-token", "--json", "--target-org", "my-alias"
+    ]
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_default_org_no_target_flag(mock_run):
+    """Without target_org, neither CLI call includes --target-org — the CLI's
+    own default-org resolution applies."""
+    mock_run.side_effect = [
+        _completed_process(_ORG_DISPLAY_OK),
+        _completed_process(_SHOW_TOKEN_OK),
+    ]
+
+    auth = SfCliAuthenticator()
+    auth.get_oauth_token()
+
+    first_call_args = mock_run.call_args_list[0].args[0]
+    second_call_args = mock_run.call_args_list[1].args[0]
+    assert "--target-org" not in first_call_args
+    assert "--target-org" not in second_call_args
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_cli_not_found(mock_run):
+    """A missing `sf` binary should raise a clear OperationalError, not a
+    raw FileNotFoundError."""
+    mock_run.side_effect = FileNotFoundError()
+
+    auth = SfCliAuthenticator()
+    with pytest.raises(OperationalError, match="Salesforce CLI"):
+        auth.get_oauth_token()
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_org_display_failure(mock_run):
+    """A non-zero status from `org display` (e.g. no authenticated org)
+    surfaces the CLI's own message and skips the token-fetch call."""
+    mock_run.side_effect = [
+        _completed_process(
+            '{"status": 1, "message": "No authorization information found for my-alias."}'
+        ),
+    ]
+
+    auth = SfCliAuthenticator(target_org="my-alias")
+    with pytest.raises(OperationalError, match="No authorization information found"):
+        auth.get_oauth_token()
+
+    assert mock_run.call_count == 1
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_show_access_token_failure(mock_run):
+    """A non-zero status from `org auth show-access-token` surfaces the
+    CLI's own message."""
+    mock_run.side_effect = [
+        _completed_process(_ORG_DISPLAY_OK),
+        _completed_process('{"status": 1, "message": "No auth found."}'),
+    ]
+
+    auth = SfCliAuthenticator(target_org="my-alias")
+    with pytest.raises(OperationalError, match="No auth found"):
+        auth.get_oauth_token()
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_malformed_json(mock_run):
+    """Non-JSON stdout raises OperationalError instead of propagating the
+    raw JSONDecodeError."""
+    mock_run.side_effect = [_completed_process("not json")]
+
+    auth = SfCliAuthenticator()
+    with pytest.raises(OperationalError):
+        auth.get_oauth_token()
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_timeout(mock_run):
+    """A CLI call that hangs past the timeout raises OperationalError."""
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="sf", timeout=30)
+
+    auth = SfCliAuthenticator()
+    with pytest.raises(OperationalError):
+        auth.get_oauth_token()
+
+
+@patch("subprocess.run")
+def test_sf_cli_auth_fetches_fresh_each_call(mock_run):
+    """Matches the no-cache model: each get_oauth_token() call re-invokes the
+    CLI rather than reusing a previous result."""
+    mock_run.side_effect = [
+        _completed_process(_ORG_DISPLAY_OK),
+        _completed_process('{"status": 0, "result": {"accessToken": "token1"}}'),
+        _completed_process(_ORG_DISPLAY_OK),
+        _completed_process('{"status": 0, "result": {"accessToken": "token2"}}'),
+    ]
+
+    auth = SfCliAuthenticator()
+    assert auth.get_oauth_token() == "token1"
+    assert auth.get_oauth_token() == "token2"
+    assert mock_run.call_count == 4

--- a/salesforce_datacloud_connector/tests/test_connection.py
+++ b/salesforce_datacloud_connector/tests/test_connection.py
@@ -251,3 +251,30 @@ def test_connect_client_credentials_requires_secret():
             client_id="test_client_id",
             # client_secret intentionally omitted
         )
+
+
+def test_connect_wires_sf_cli():
+    """connect(auth_type='sf_cli') composes SfCliAuthenticator → DataCloudTokenExchanger
+    → Connection, with no connected-app credentials required (local/dev flow)."""
+    from unittest.mock import patch
+    import salesforce_datacloud_connector as sfdc
+    from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
+    from salesforce_datacloud_connector.auth.oauth import SfCliAuthenticator
+
+    with patch.object(SfCliAuthenticator, '_fetch_new_token', return_value=("core_token", 7200, "https://test.salesforce.com")), \
+         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")):
+            conn = sfdc.connect(
+                auth_type="sf_cli",
+                target_org="my-alias",
+                dataspace="test_ds",
+                workload="test_workload",
+            )
+
+            assert conn is not None
+            assert isinstance(conn, sfdc.Connection)
+            authenticator = conn._token_provider._core_authenticator
+            assert isinstance(authenticator, SfCliAuthenticator)
+            assert authenticator.target_org == "my-alias"
+            assert conn._client.tenant_endpoint == "https://tenant.c360a.salesforce.com"
+
+            conn.close()

--- a/salesforce_datacloud_connector/tests/test_connection.py
+++ b/salesforce_datacloud_connector/tests/test_connection.py
@@ -253,6 +253,37 @@ def test_connect_client_credentials_requires_secret():
         )
 
 
+def test_connect_positional_args_backward_compatible():
+    """connect()'s pre-target_org positional parameter order (…, dataspace,
+    workload) must still bind correctly — target_org must not shift dataspace
+    and workload out of their original positions for existing positional
+    callers."""
+    from unittest.mock import patch
+    import salesforce_datacloud_connector as sfdc
+    from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
+    from salesforce_datacloud_connector.auth.oauth import ClientCredentialsAuthenticator
+
+    with patch.object(ClientCredentialsAuthenticator, '_fetch_new_token', return_value=("core_token", 7200, "https://test.salesforce.com")), \
+         patch.object(DataCloudTokenExchanger, '_exchange_token', return_value=("cdp_token", 7200, "https://tenant.c360a.salesforce.com")):
+            conn = sfdc.connect(
+                "https://login.salesforce.com",  # login_url
+                "client_credentials",  # auth_type
+                None,  # username
+                None,  # password
+                "test_client_id",  # client_id
+                "test_client_secret",  # client_secret
+                None,  # jwt_private_key
+                None,  # refresh_token
+                "test_ds",  # dataspace
+                "test_workload",  # workload
+            )
+
+            assert conn.dataspace == "test_ds"
+            assert conn.workload == "test_workload"
+
+            conn.close()
+
+
 def test_connect_wires_sf_cli():
     """connect(auth_type='sf_cli') composes SfCliAuthenticator → DataCloudTokenExchanger
     → Connection, with no connected-app credentials required (local/dev flow)."""


### PR DESCRIPTION
Adds SfCliAuthenticator (auth_type="sf_cli"), which reuses whatever org the `sf` CLI is already authenticated against instead of requiring a connected app client_id/secret or JWT key. Fetches instance URL via `sf org display` and the access token via `sf org auth show-access-token` (recent CLI versions redact the token from the first command's output). Forces NO_COLOR=1 on the subprocess so --json output stays parseable even when the caller's shell sets FORCE_COLOR.