### PR TITLE
feat(threadsafety): raise v3 connector threadsafety 1 -> 2 (v1 parity) @W-24004700

### DIFF
--- a/salesforce_datacloud_connector/CHANGELOG.md
+++ b/salesforce_datacloud_connector/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0b2 — Beta release (TBD)
+
+### Changed
+- Raised DB-API 2.0 `threadsafety` from `1` to `2`: threads may now share a
+  single `Connection` (and its cursor factory), not just the module. This
+  reaches parity with the legacy v1 driver. Cursors remain thread-confined and
+  must not be shared across threads.
+
+### Fixed
+- Connection-shared authentication state is now thread-safe. The core
+  authenticator publishes its `instance_url` and pairs `(access_token,
+  instance_url)` atomically from a single fetch, and the CDP token exchanger
+  caches the token, its expiry, and the tenant endpoint as one immutable
+  snapshot published atomically under a lock (double-checked locking). Cold-miss
+  fetches/exchanges are single-flighted, so N racing threads trigger one fetch
+  rather than a thundering herd, and a reader can never observe a token paired
+  with a mismatched endpoint.
+- `DataCloudTokenExchanger.invalidate_token()` now clears the tenant endpoint
+  along with the token and expiry, so a subsequent `get_tenant_endpoint()`
+  re-exchanges instead of returning a stale endpoint.
+
 ## 2.0.0b1 — Beta release (TBD)
 
 First public beta of the new `salesforce-datacloud-connector` package, the

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/__init__.py
@@ -29,7 +29,7 @@ from typing import Optional
 
 # DB-API 2.0 module globals
 apilevel = "2.0"  # DB-API specification version
-threadsafety = 1  # Threads may share the module, but not connections
+threadsafety = 2  # Threads may share the module and connections, but not cursors
 paramstyle = "named"  # Named parameter style (:param)
 
 # Import and expose exceptions

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/oauth.py
@@ -12,9 +12,10 @@ the JDBC driver's DataCloudTokenProvider.
 
 from __future__ import annotations
 
+import threading
 import time
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Tuple
 
 import jwt
 import requests
@@ -40,6 +41,10 @@ class OAuthAuthenticator(ABC):
         """
         self.login_url = login_url.rstrip("/")
         self._instance_url: Optional[str] = None
+        # Guards publication of self._instance_url and single-flights the
+        # cold-miss fetch in get_instance_url() so one shared authenticator is
+        # safe to use from multiple threads (threadsafety=2).
+        self._lock = threading.Lock()
 
     @abstractmethod
     def _fetch_new_token(self) -> tuple[str, int, str]:
@@ -54,6 +59,34 @@ class OAuthAuthenticator(ABC):
         """
         pass
 
+    def get_oauth_token_and_instance_url(self) -> Tuple[str, str]:
+        """
+        Fetch a fresh core token and return it paired with its instance URL.
+
+        Both values come from the SAME fetch, so a caller never pairs one
+        fetch's token with another fetch's instance URL — the mismatch that a
+        shared authenticator would otherwise expose when get_oauth_token() and
+        get_instance_url() are called separately by racing threads.
+
+        The (potentially slow) HTTP fetch runs OUTSIDE the lock so concurrent
+        callers do not serialize on the network round-trip; only the tiny
+        publication of self._instance_url is guarded, keeping get_instance_url()
+        readers consistent.
+
+        Matches the JDBC driver's DataCloudTokenProvider.getOAuthToken(): the
+        core token is always fetched fresh (never cached).
+
+        Returns:
+            (access_token, instance_url) from one fetch
+
+        Raises:
+            OperationalError: If authentication fails
+        """
+        access_token, _expires_in, instance_url = self._fetch_new_token()
+        with self._lock:
+            self._instance_url = instance_url
+        return access_token, instance_url
+
     def get_oauth_token(self) -> str:
         """
         Fetch a fresh OAuth token.
@@ -67,16 +100,18 @@ class OAuthAuthenticator(ABC):
         Raises:
             OperationalError: If authentication fails
         """
-        access_token, _expires_in, instance_url = self._fetch_new_token()
-        self._instance_url = instance_url
-
+        access_token, _instance_url = self.get_oauth_token_and_instance_url()
         return access_token
 
     def get_instance_url(self) -> str:
         """
         Get the Salesforce instance URL returned by OAuth.
 
-        This URL is extracted from the OAuth response and should be used for all API calls.
+        This URL is extracted from the OAuth response and should be used for all
+        API calls. Unlike the core token, the instance URL is stable org
+        metadata, so it is cached after the first fetch: a cold miss is
+        single-flighted under the lock (double-checked locking) so N concurrent
+        first-callers trigger exactly ONE fetch, not a thundering herd.
 
         Returns:
             Salesforce instance URL (e.g., "https://myorg.my.salesforce.com")
@@ -84,9 +119,17 @@ class OAuthAuthenticator(ABC):
         Raises:
             OperationalError: If no token has been fetched yet
         """
-        if self._instance_url is None:
-            # Trigger token fetch to get instance URL
-            self.get_oauth_token()
+        # Fast path: already published, no lock needed.
+        if self._instance_url is not None:
+            return self._instance_url
+
+        with self._lock:
+            # Re-check under the lock — another thread may have published while
+            # we waited. Fetch directly (not via get_oauth_token, which would
+            # re-acquire this non-reentrant lock) so the cold miss fetches once.
+            if self._instance_url is None:
+                _access_token, _expires_in, instance_url = self._fetch_new_token()
+                self._instance_url = instance_url
 
         if self._instance_url is None:
             raise OperationalError("Instance URL not available from OAuth response")

--- a/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
+++ b/salesforce_datacloud_connector/salesforce_datacloud_connector/auth/token_exchanger.py
@@ -7,13 +7,21 @@ Data Cloud (CDP) tokens via the /services/a360/token endpoint.
 
 from __future__ import annotations
 
+import threading
 import time
+from collections import namedtuple
 from typing import Optional
 
 import requests
 
 from ..exceptions import OperationalError
 from .oauth import OAuthAuthenticator
+
+# Immutable snapshot of the three values a single CDP exchange produces. Bundling
+# them into one namedtuple lets us publish them with a single atomic reference
+# assignment (self._cache = _CdpTokenCache(...)), so a reader can never observe a
+# token from one exchange paired with a tenant endpoint from another (torn read).
+_CdpTokenCache = namedtuple("_CdpTokenCache", ["token", "expiry", "tenant_endpoint"])
 
 
 class DataCloudTokenExchanger:
@@ -48,9 +56,64 @@ class DataCloudTokenExchanger:
         """
         self._core_authenticator = core_authenticator
         self._dataspace = dataspace
-        self._cached_cdp_token: Optional[str] = None
-        self._token_expiry: Optional[float] = None
-        self._tenant_endpoint: Optional[str] = None
+        # Single atomic reference to the current cache snapshot (None = cold).
+        # Publishing a fresh _CdpTokenCache in one assignment keeps token, expiry
+        # and tenant_endpoint mutually consistent for every reader.
+        self._cache: Optional[_CdpTokenCache] = None
+        # Guards the cold-miss / expiry re-exchange so a shared exchanger is safe
+        # across threads (threadsafety=2): N racing misses do ONE exchange, not a
+        # thundering herd.
+        self._lock = threading.Lock()
+
+    def _ensure_cache(self) -> _CdpTokenCache:
+        """
+        Return a live CDP cache snapshot, exchanging a new one if needed.
+
+        Uses double-checked locking: the common hit takes the unlocked fast path;
+        only an apparent miss acquires the lock, then re-checks so a single thread
+        performs the exchange while the others reuse its freshly published snapshot
+        (rather than each firing their own — the pre-lock thundering herd).
+
+        Liveness mirrors JDBC's DataCloudToken.isAlive(): a snapshot is alive while
+        current_time <= expiry, with no refresh buffer. The (potentially slow) core
+        fetch + exchange run under the lock so concurrent cold callers dedup to one
+        network round-trip.
+
+        Returns:
+            A live _CdpTokenCache snapshot
+
+        Raises:
+            OperationalError: If token exchange fails
+        """
+        # Fast path: a live snapshot needs no lock.
+        snapshot = self._cache
+        if snapshot is not None and time.time() <= snapshot.expiry:
+            return snapshot
+
+        with self._lock:
+            # Re-check under the lock — another thread may have exchanged while we
+            # waited, in which case we reuse its snapshot instead of exchanging.
+            snapshot = self._cache
+            if snapshot is not None and time.time() <= snapshot.expiry:
+                return snapshot
+
+            # Fetch a fresh core token paired with its instance URL from ONE fetch
+            # (the core authenticator never caches), then exchange for a CDP token.
+            core_token, instance_url = (
+                self._core_authenticator.get_oauth_token_and_instance_url()
+            )
+            cdp_token, expires_in, tenant_endpoint = self._exchange_token(
+                instance_url, core_token
+            )
+
+            # Publish the whole snapshot atomically in one reference assignment.
+            snapshot = _CdpTokenCache(
+                token=cdp_token,
+                expiry=time.time() + expires_in,
+                tenant_endpoint=tenant_endpoint,
+            )
+            self._cache = snapshot
+            return snapshot
 
     def get_cdp_token(self) -> str:
         """
@@ -66,37 +129,16 @@ class DataCloudTokenExchanger:
         Raises:
             OperationalError: If token exchange fails
         """
-        current_time = time.time()
-
-        # Check cache — alive until exact expiry, no buffer.
-        if (
-            self._cached_cdp_token is not None
-            and self._token_expiry is not None
-            and current_time <= self._token_expiry
-        ):
-            return self._cached_cdp_token
-
-        # Exchange a fresh core token for a CDP token
-        core_token = self._core_authenticator.get_oauth_token()
-        instance_url = self._core_authenticator.get_instance_url()
-
-        cdp_token, expires_in, tenant_endpoint = self._exchange_token(
-            instance_url, core_token
-        )
-
-        # Cache CDP token
-        self._cached_cdp_token = cdp_token
-        self._token_expiry = current_time + expires_in
-        self._tenant_endpoint = tenant_endpoint
-
-        return cdp_token
+        return self._ensure_cache().token
 
     def get_tenant_endpoint(self) -> str:
         """
         Get the Data Cloud tenant endpoint URL.
 
         The tenant endpoint is returned by the CDP token exchange and is used
-        as the base URL for all off-core v3 API calls.
+        as the base URL for all off-core v3 API calls. It is drawn from the SAME
+        snapshot as the CDP token, so the two can never come from different
+        exchanges.
 
         Returns:
             Data Cloud tenant endpoint (e.g., "https://{tenant}.c360a.salesforce.com")
@@ -104,23 +146,23 @@ class DataCloudTokenExchanger:
         Raises:
             OperationalError: If no token exchange has occurred yet
         """
-        if self._tenant_endpoint is None:
-            # Trigger exchange to get tenant endpoint
-            self.get_cdp_token()
-
-        if self._tenant_endpoint is None:
+        tenant_endpoint = self._ensure_cache().tenant_endpoint
+        if tenant_endpoint is None:
             raise OperationalError("Tenant endpoint not available from CDP token exchange")
-
-        return self._tenant_endpoint
+        return tenant_endpoint
 
     def invalidate_token(self):
         """
         Invalidate the cached CDP token, forcing a re-exchange on next request.
 
+        Clears the whole snapshot atomically (token, expiry AND tenant_endpoint),
+        so a subsequent get_tenant_endpoint() re-exchanges rather than returning a
+        stale endpoint.
+
         Note: This does NOT invalidate the core authenticator's token.
         """
-        self._cached_cdp_token = None
-        self._token_expiry = None
+        with self._lock:
+            self._cache = None
 
     def _exchange_token(
         self, instance_url: str, core_token: str

--- a/salesforce_datacloud_connector/tests/_concurrency_helpers.py
+++ b/salesforce_datacloud_connector/tests/_concurrency_helpers.py
@@ -1,0 +1,129 @@
+"""
+Deterministic concurrency test utilities.
+
+The point of these helpers is to make "N threads race into a contended section"
+reproducible on every run instead of relying on scheduling luck:
+
+* ``run_concurrently`` starts one thread per party, holds them all at a
+  ``threading.Barrier`` so they enter the worker body simultaneously, then
+  collects each worker's result (by index) and any exception it raised.
+
+* ``ConcurrencyGate`` is a counting gate a worker calls from inside the
+  section a lock is supposed to protect (e.g. the token-fetch / exchange). It
+  records how many callers reached the section (``entered``) and the peak
+  number that were inside it at once (``max_concurrent``), and it *holds*
+  callers there long enough to expose overlap:
+
+    - if every party reaches the gate, they pile up and are released together
+      (this is the thundering-herd signature of unlocked check-then-act code);
+    - if fewer than all parties arrive, the gate releases the ones present
+      after ``pileup_timeout`` (the signature of correctly locked code, where
+      exactly one caller reaches the fetch and the rest see the published
+      value and never enter).
+
+  A properly double-checked-locked cache therefore yields ``entered == 1`` and
+  ``max_concurrent == 1``; the pre-fix racy code yields both equal to the party
+  count. That gap is what the Stage 2/3 production tests assert on.
+"""
+
+import threading
+from typing import Callable, List, Tuple
+
+
+def run_concurrently(
+    worker: Callable[[int], object],
+    parties: int,
+    start_timeout: float = 10.0,
+    join_timeout: float = 30.0,
+) -> Tuple[List[object], List[Tuple[int, BaseException]]]:
+    """Run ``worker(i)`` for ``i`` in ``range(parties)``, each in its own thread,
+    all released simultaneously.
+
+    Returns ``(results, errors)`` where ``results[i]`` is worker ``i``'s return
+    value (``None`` if it raised) and ``errors`` is a list of ``(i, exception)``
+    sorted by index for every worker that raised.
+    """
+    results: List[object] = [None] * parties
+    errors: List[Tuple[int, BaseException]] = []
+    errors_lock = threading.Lock()
+    start_barrier = threading.Barrier(parties)
+
+    def runner(i: int) -> None:
+        # Release all workers into the body at the same instant so the race is
+        # real, not an artifact of staggered thread start-up.
+        start_barrier.wait(timeout=start_timeout)
+        try:
+            results[i] = worker(i)
+        except BaseException as exc:  # noqa: BLE001 - surface every failure to the test
+            with errors_lock:
+                errors.append((i, exc))
+
+    threads = [threading.Thread(target=runner, args=(i,)) for i in range(parties)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=join_timeout)
+
+    errors.sort(key=lambda pair: pair[0])
+    return results, errors
+
+
+class ConcurrencyGate:
+    """A counting gate used from inside the section a lock should serialize.
+
+    See the module docstring for the discrimination it provides between racy
+    and correctly-locked code.
+    """
+
+    def __init__(self) -> None:
+        self._cond = threading.Condition()
+        self.entered = 0
+        self.max_concurrent = 0
+        self._current = 0
+        self._parties = 0
+        self._pileup_timeout = 0.5
+        self._released = False
+
+    def enter(self) -> None:
+        """Mark that a caller reached the contended section, and block until the
+        gate releases (either the whole herd assembled, or ``pileup_timeout``
+        elapsed with only some present)."""
+        with self._cond:
+            self.entered += 1
+            self._current += 1
+            if self._current > self.max_concurrent:
+                self.max_concurrent = self._current
+
+            if self.entered >= self._parties:
+                # Whole herd assembled — release everyone at once.
+                self._released = True
+                self._cond.notify_all()
+            else:
+                # Wait for the rest of the herd; if they never come (the locked
+                # case, where only one caller reaches here), give up after the
+                # pileup timeout and proceed.
+                self._cond.wait_for(lambda: self._released, timeout=self._pileup_timeout)
+                self._released = True
+                self._cond.notify_all()
+
+            self._current -= 1
+
+    def run(
+        self,
+        worker: Callable[[int], object],
+        parties: int,
+        pileup_timeout: float = 0.5,
+    ) -> Tuple[List[object], List[Tuple[int, BaseException]]]:
+        """Reset the gate for ``parties`` workers and run them concurrently.
+
+        Returns the same ``(results, errors)`` tuple as ``run_concurrently``.
+        """
+        with self._cond:
+            self.entered = 0
+            self.max_concurrent = 0
+            self._current = 0
+            self._parties = parties
+            self._pileup_timeout = pileup_timeout
+            self._released = False
+
+        return run_concurrently(worker, parties)

--- a/salesforce_datacloud_connector/tests/test_api_client.py
+++ b/salesforce_datacloud_connector/tests/test_api_client.py
@@ -3,6 +3,7 @@ Tests for Data Cloud Query API client.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 import responses
@@ -10,11 +11,34 @@ import responses
 from salesforce_datacloud_connector.api.client import DataCloudQueryClient
 from salesforce_datacloud_connector.api.models import QueryStatus
 from salesforce_datacloud_connector.exceptions import OperationalError, ProgrammingError
+from tests._concurrency_helpers import ConcurrencyGate
 
 
 def mock_token_getter():
     """Mock token getter for tests."""
     return "mock_token_12345"
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response used by the concurrency tests.
+
+    ``responses`` mutates a global registry and is not thread-safe, so the
+    shared-client concurrency tests patch ``requests.request`` directly with a
+    thread-safe fake instead.
+    """
+
+    def __init__(self, status_code, json_body, headers=None):
+        self.status_code = status_code
+        self._json = json_body
+        self.headers = headers or {}
+        self.text = ""
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._json
 
 
 @responses.activate
@@ -766,3 +790,104 @@ def test_query_status_unknown_keys_ignored():
         }
     )
     assert status.is_complete()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: a single DataCloudQueryClient shared across threads.
+#
+# threadsafety=2 requires that one connection (hence its one shared query
+# client) be usable from multiple threads at once. The client holds no
+# per-request mutable state — each call builds its own request body, headers,
+# and parses its own response — so concurrent callers must not see each other's
+# query IDs or rows bleed across. These tests pin that invariant so a future
+# change that introduces shared mutable request state fails loudly.
+# ---------------------------------------------------------------------------
+
+
+def _status_header(query_id):
+    return {
+        "x-hyperdb-status": json.dumps(
+            {
+                "queryId": query_id,
+                "completionStatus": "RESULTS_PRODUCED",
+                "progress": 1.0,
+                "rowCount": 1,
+                "chunkCount": 1,
+            }
+        )
+    }
+
+
+def test_shared_client_concurrent_execute_query_keeps_responses_distinct():
+    """N threads issuing distinct queries through ONE shared client each get
+    back their own query id and rows — no cross-thread bleed of request or
+    response state."""
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+    parties = 12
+    gate = ConcurrencyGate()
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        # The per-thread query id is carried in the SQL so the fake can echo it
+        # back in both the body and the status header. Hold every caller inside
+        # the request so their responses are genuinely built concurrently.
+        sql = json["sql"]
+        gate.enter()
+        marker = sql.split("'")[1]
+        return _FakeResponse(
+            200,
+            {"metadata": {"columns": [{"name": "m", "type": "varchar", "nullable": True}]},
+             "data": [[marker]], "returnedRows": 1},
+            headers=_status_header(f"query_{marker}"),
+        )
+
+    def worker(i):
+        return client.execute_query(f"SELECT '{i}' AS m")
+
+    # Patch once in the main thread: patch() setattrs requests.request globally,
+    # so the fake is visible to every worker thread. All threads start and join
+    # inside this context, so the patch outlives them. (Patching per-thread
+    # would race — concurrent setattr on the same module attribute.)
+    with patch("requests.request", side_effect=fake_request):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    assert gate.entered == parties
+    assert gate.max_concurrent == parties  # all genuinely in-flight together
+    # Each worker sees exactly its own marker echoed back — no cross-talk.
+    for i, resp in enumerate(results):
+        assert resp.status.query_id == f"query_{i}"
+        assert resp.data == [[str(i)]]
+
+
+def test_shared_client_concurrent_fetch_results_keeps_rows_distinct():
+    """Concurrent fetch_results() calls on one shared client return each
+    caller's own rows, proving fetch has no shared per-call buffer."""
+    client = DataCloudQueryClient(
+        tenant_endpoint="https://test.c360a.salesforce.com",
+        auth_token_getter=mock_token_getter,
+    )
+    parties = 12
+    gate = ConcurrencyGate()
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        # URL is .../query/{query_id}/rows — echo the id back as the row value.
+        query_id = url.split("/query/")[1].split("/rows")[0]
+        gate.enter()
+        return _FakeResponse(
+            200,
+            {"metadata": [], "data": [[query_id]], "returnedRows": 1},
+        )
+
+    def worker(i):
+        return client.fetch_results(query_id=f"q{i}", offset=0)
+
+    with patch("requests.request", side_effect=fake_request):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    assert gate.entered == parties
+    for i, resp in enumerate(results):
+        assert resp.data == [[f"q{i}"]]

--- a/salesforce_datacloud_connector/tests/test_auth.py
+++ b/salesforce_datacloud_connector/tests/test_auth.py
@@ -2,6 +2,7 @@
 Tests for OAuth authentication.
 """
 
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +14,7 @@ from salesforce_datacloud_connector.auth.oauth import (
     UsernamePasswordAuthenticator,
 )
 from salesforce_datacloud_connector.exceptions import OperationalError
+from tests._concurrency_helpers import ConcurrencyGate
 
 
 @responses.activate
@@ -301,3 +303,80 @@ def test_client_credentials_auth_failure():
 
     with pytest.raises(OperationalError):
         auth.get_oauth_token()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency (threadsafety=2): a single authenticator shared across threads.
+# ---------------------------------------------------------------------------
+
+
+def _make_username_authenticator():
+    return UsernamePasswordAuthenticator(
+        login_url="https://test.salesforce.com",
+        username="test@example.com",
+        password="password123",
+        client_id="client_id",
+        client_secret="client_secret",
+    )
+
+
+def test_concurrent_get_instance_url_fetches_exactly_once():
+    """N threads calling get_instance_url() on a cold authenticator must trigger
+    exactly ONE token fetch. instance_url is stable org metadata; the unlocked
+    check-then-fetch admits every caller (thundering herd), so this fails until
+    get_instance_url() dedups the cold miss under a lock (double-checked)."""
+    auth = _make_username_authenticator()
+    parties = 8
+    gate = ConcurrencyGate()
+
+    def fake_fetch():
+        gate.enter()  # counts every caller that reaches the fetch
+        return ("token", 7200, "https://myorg.my.salesforce.com")
+
+    def worker(_i):
+        return auth.get_instance_url()
+
+    with patch.object(auth, "_fetch_new_token", side_effect=fake_fetch):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    assert all(r == "https://myorg.my.salesforce.com" for r in results)
+    assert gate.entered == 1  # deduplicated: only one thread fetched
+    assert gate.max_concurrent == 1
+
+
+def test_get_oauth_token_and_instance_url_returns_matched_pair_under_concurrency():
+    """get_oauth_token_and_instance_url() must return a (token, instance_url)
+    pair drawn from the SAME fetch. Composing get_oauth_token() +
+    get_instance_url() as two separate calls could pair one thread's token with
+    another thread's instance_url; the atomic pair method must never mismatch.
+
+    Each fetch here returns a distinct token whose org number is embedded in
+    both the token and its instance_url, so any cross-fetch pairing is caught."""
+    auth = _make_username_authenticator()
+    parties = 16
+    gate = ConcurrencyGate()
+    counter = {"n": 0}
+    counter_lock = threading.Lock()
+
+    def fake_fetch():
+        with counter_lock:
+            counter["n"] += 1
+            n = counter["n"]
+        gate.enter()  # hold all callers together so fetches genuinely overlap
+        return (f"token{n}", 7200, f"https://org{n}.my.salesforce.com")
+
+    def worker(_i):
+        return auth.get_oauth_token_and_instance_url()
+
+    with patch.object(auth, "_fetch_new_token", side_effect=fake_fetch):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    # Core tokens are never cached: every caller performs its own fresh fetch.
+    assert gate.entered == parties
+    assert gate.max_concurrent == parties
+    # Every returned pair is internally consistent — url matches its own token.
+    for token, url in results:
+        n = token[len("token"):]
+        assert url == f"https://org{n}.my.salesforce.com"

--- a/salesforce_datacloud_connector/tests/test_concurrency_helpers.py
+++ b/salesforce_datacloud_connector/tests/test_concurrency_helpers.py
@@ -1,0 +1,76 @@
+"""
+Tests for the deterministic concurrency test utilities themselves.
+
+These prove the helper can *discriminate* a thundering-herd race (an unlocked
+check-then-fetch admits every caller) from a correctly double-checked-locked
+cache (exactly one caller reaches the fetch). If the gate did not actually hold
+callers until release, one of these two assertions would fail — so together
+they are the helper's own safety net, which the Stage 2/3 production tests then
+rely on.
+"""
+
+import threading
+
+from tests._concurrency_helpers import ConcurrencyGate, run_concurrently
+
+
+def test_run_concurrently_collects_results_and_errors_by_index():
+    """run_concurrently returns each worker's result at its index and surfaces
+    raised exceptions rather than swallowing them."""
+    def worker(i):
+        if i == 3:
+            raise ValueError("boom")
+        return i * 10
+
+    results, errors = run_concurrently(worker, parties=5)
+
+    assert results[0] == 0
+    assert results[1] == 10
+    assert results[2] == 20
+    assert results[4] == 40
+    assert [(i, type(e)) for i, e in errors] == [(3, ValueError)]
+
+
+def test_gate_detects_thundering_herd_without_lock():
+    """An unlocked check-then-fetch cache lets all N callers reach the fetch.
+    The gate must observe every entry — this is the race a lock would prevent."""
+    gate = ConcurrencyGate()
+    parties = 8
+    state = {"value": None}
+
+    def unlocked_get(_i):
+        if state["value"] is None:        # racy check
+            gate.enter()                  # held open until release()
+            state["value"] = "computed"   # racy write
+        return state["value"]
+
+    results, errors = gate.run(unlocked_get, parties)
+
+    assert errors == []
+    assert all(r == "computed" for r in results)
+    assert gate.entered == parties          # every caller fetched
+    assert gate.max_concurrent == parties   # genuinely concurrent
+
+
+def test_gate_confirms_single_fetch_with_double_checked_lock():
+    """A correctly double-checked-locked cache admits exactly one fetch even
+    though N callers race in. The gate must observe exactly one entry."""
+    gate = ConcurrencyGate()
+    parties = 8
+    lock = threading.Lock()
+    state = {"value": None}
+
+    def locked_get(_i):
+        if state["value"] is None:              # fast path (unlocked)
+            with lock:
+                if state["value"] is None:      # re-check under lock
+                    gate.enter()                # only the winner reaches here
+                    state["value"] = "computed"
+        return state["value"]
+
+    results, errors = gate.run(locked_get, parties, pileup_timeout=0.5)
+
+    assert errors == []
+    assert all(r == "computed" for r in results)
+    assert gate.entered == 1
+    assert gate.max_concurrent == 1

--- a/salesforce_datacloud_connector/tests/test_connection.py
+++ b/salesforce_datacloud_connector/tests/test_connection.py
@@ -9,6 +9,7 @@ import pytest
 from salesforce_datacloud_connector.connection import Connection
 from salesforce_datacloud_connector.cursor import Cursor
 from salesforce_datacloud_connector.exceptions import InterfaceError
+from tests._concurrency_helpers import run_concurrently
 
 
 def create_mock_token_provider():
@@ -251,3 +252,62 @@ def test_connect_client_credentials_requires_secret():
             client_id="test_client_id",
             # client_secret intentionally omitted
         )
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: one Connection shared across threads (threadsafety=2).
+#
+# Cursors are thread-CONFINED, but creating them from a shared Connection must
+# be safe: cursor() must hand every thread its own distinct Cursor bound to the
+# one shared client, and the benign close()/cursor() race must never corrupt
+# state. These characterize the connection's existing safety so the
+# threadsafety=2 promise has a regression guard.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_cursor_creation_returns_distinct_cursors():
+    """N threads calling cursor() on one shared Connection each get a distinct
+    Cursor object, all bound to the connection's single shared client."""
+    conn = Connection(create_mock_token_provider())
+    parties = 16
+
+    def worker(_i):
+        return conn.cursor()
+
+    results, errors = run_concurrently(worker, parties)
+
+    assert errors == []
+    assert all(isinstance(c, Cursor) for c in results)
+    # Every cursor is a distinct object...
+    assert len({id(c) for c in results}) == parties
+    # ...yet all share the connection's one client instance.
+    assert all(c._client is conn._client for c in results)
+
+
+def test_concurrent_close_and_cursor_race_is_benign():
+    """Threads racing cursor() against close() never raise anything other than
+    the documented InterfaceError, and the connection ends up closed."""
+    conn = Connection(create_mock_token_provider())
+    parties = 16
+
+    def worker(i):
+        if i % 4 == 0:
+            conn.close()
+            return "closed"
+        try:
+            return conn.cursor()
+        except InterfaceError:
+            # Legal outcome: connection was closed by a racing thread.
+            return "interface_error"
+
+    results, errors = run_concurrently(worker, parties)
+
+    # No unexpected exception type escaped — only the documented InterfaceError,
+    # which workers convert to a sentinel. Any other raise would appear here.
+    assert errors == []
+    assert conn.closed
+    # Every result is one of the three legal outcomes.
+    assert all(
+        r == "closed" or r == "interface_error" or isinstance(r, Cursor)
+        for r in results
+    )

--- a/salesforce_datacloud_connector/tests/test_threadsafety.py
+++ b/salesforce_datacloud_connector/tests/test_threadsafety.py
@@ -1,0 +1,163 @@
+"""
+End-to-end thread-safety tests for the DB-API 2.0 driver (threadsafety=2).
+
+threadsafety=2 (PEP 249) means threads may share the module AND connections,
+but not cursors. These tests tie the per-component guarantees together:
+
+- the module advertises threadsafety == 2;
+- many threads sharing ONE Connection can each open their own cursor and run a
+  query end-to-end without their rows bleeding across;
+- two connection-scoped token exchangers sharing ONE core authenticator can
+  fetch concurrently without error.
+
+Cursors are thread-confined by design and are intentionally NOT shared here.
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+import salesforce_datacloud_connector as sfdc
+from salesforce_datacloud_connector.auth.oauth import UsernamePasswordAuthenticator
+from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
+from salesforce_datacloud_connector.connection import Connection
+from tests._concurrency_helpers import ConcurrencyGate
+
+
+class _FakeResponse:
+    """Minimal thread-safe stand-in for requests.Response (``responses`` is not
+    thread-safe, so the concurrency tests patch requests.request directly)."""
+
+    def __init__(self, status_code, json_body, headers=None):
+        self.status_code = status_code
+        self._json = json_body
+        self.headers = headers or {}
+        self.text = ""
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._json
+
+
+def _status_header(query_id):
+    return {
+        "x-hyperdb-status": json.dumps(
+            {
+                "queryId": query_id,
+                "completionStatus": "RESULTS_PRODUCED",
+                "progress": 1.0,
+                "rowCount": 1,
+                "chunkCount": 1,
+            }
+        )
+    }
+
+
+def _mock_token_provider():
+    """A token provider whose tenant endpoint / CDP token are pre-resolved, so
+    Connection construction needs no network."""
+    provider = Mock()
+    provider.get_tenant_endpoint.return_value = "https://test.c360a.salesforce.com"
+    provider.get_cdp_token.return_value = "mock_cdp_token"
+    return provider
+
+
+def test_module_advertises_threadsafety_2():
+    """PEP 249: threadsafety == 2 tells callers a single Connection is safe to
+    share across threads (cursors are not). This is the headline promise of the
+    whole change; it stays 1 until the module global is flipped."""
+    assert sfdc.threadsafety == 2
+
+
+def test_shared_connection_end_to_end_queries_keep_rows_distinct():
+    """Many threads share ONE Connection: each opens its own cursor, runs its own
+    query, and fetches its own rows end-to-end (execute → fetchall). No thread
+    sees another's rows — the concrete threadsafety=2 guarantee."""
+    conn = Connection(_mock_token_provider())
+    parties = 12
+    gate = ConcurrencyGate()
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        # The per-thread marker rides in the SQL; echo it back in both the row
+        # data and the status header. Hold every caller inside the request so the
+        # responses are genuinely built concurrently on the shared connection.
+        sql = json["sql"]
+        gate.enter()
+        marker = sql.split("'")[1]
+        return _FakeResponse(
+            200,
+            {
+                "metadata": {"columns": [{"name": "m", "type": "varchar", "nullable": True}]},
+                "data": [[marker]],
+                "returnedRows": 1,
+            },
+            headers=_status_header(f"query_{marker}"),
+        )
+
+    def worker(i):
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT '{i}' AS m")
+        rows = cursor.fetchall()
+        cursor.close()
+        return rows
+
+    # Patch once in the main thread: patch() setattrs requests.request globally so
+    # the fake is visible to every worker; all threads start+join inside it.
+    with patch("requests.request", side_effect=fake_request):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    assert gate.entered == parties
+    assert gate.max_concurrent == parties  # all genuinely in-flight on one conn
+    # Every thread got exactly its own row back — no cross-talk.
+    for i, rows in enumerate(results):
+        assert rows == [(str(i),)]
+    assert not conn.closed
+
+
+def test_two_exchangers_sharing_one_authenticator_are_concurrency_safe():
+    """Two connection-scoped DataCloudTokenExchangers wrapping ONE shared core
+    authenticator can exchange concurrently without error. Each exchanger single-
+    flights its own cold miss; the shared authenticator serves every core fetch
+    safely (matches the real topology of two Connections over one authenticator)."""
+    auth = UsernamePasswordAuthenticator(
+        login_url="https://test.salesforce.com",
+        username="test@example.com",
+        password="password123",
+        client_id="client_id",
+        client_secret="client_secret",
+    )
+    exchanger_a = DataCloudTokenExchanger(core_authenticator=auth, dataspace="a")
+    exchanger_b = DataCloudTokenExchanger(core_authenticator=auth, dataspace="b")
+    exchangers = [exchanger_a, exchanger_b]
+    parties = 16
+    gate = ConcurrencyGate()
+
+    def fake_fetch():
+        return ("core_token", 7200, "https://myorg.my.salesforce.com")
+
+    def make_fake_exchange(tag):
+        def fake_exchange(instance_url, core_token):
+            gate.enter()
+            return (f"cdp_{tag}", 3600, f"https://{tag}.c360a.salesforce.com")
+
+        return fake_exchange
+
+    def worker(i):
+        exchanger = exchangers[i % 2]
+        return exchanger.get_cdp_token()
+
+    with patch.object(auth, "_fetch_new_token", side_effect=fake_fetch), patch.object(
+        exchanger_a, "_exchange_token", side_effect=make_fake_exchange("a")
+    ), patch.object(exchanger_b, "_exchange_token", side_effect=make_fake_exchange("b")):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    # Each exchanger single-flights its own cold miss → exactly two exchanges
+    # total across the two exchangers, regardless of party count.
+    assert gate.entered == 2
+    # Every caller sees its own exchanger's token.
+    for i, token in enumerate(results):
+        assert token == ("cdp_a" if i % 2 == 0 else "cdp_b")

--- a/salesforce_datacloud_connector/tests/test_token_exchanger.py
+++ b/salesforce_datacloud_connector/tests/test_token_exchanger.py
@@ -2,6 +2,7 @@
 Tests for DataCloudTokenExchanger (core token → CDP token exchange).
 """
 
+import threading
 import time
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ import responses
 from salesforce_datacloud_connector.auth.oauth import JWTAuthenticator
 from salesforce_datacloud_connector.auth.token_exchanger import DataCloudTokenExchanger
 from salesforce_datacloud_connector.exceptions import OperationalError
+from tests._concurrency_helpers import ConcurrencyGate
 
 
 @responses.activate
@@ -647,3 +649,105 @@ def test_client_credentials_token_exchange_success():
     assert "/services/oauth2/token" in responses.calls[0].request.url  # Core token
     assert "grant_type=client_credentials" in responses.calls[0].request.body
     assert "/services/a360/token" in responses.calls[1].request.url  # Exchange
+
+
+# ---------------------------------------------------------------------------
+# Concurrency (threadsafety=2): one exchanger shared across threads.
+#
+# The CDP token + tenant endpoint are org-scoped, cacheable state. On a cold
+# miss, N racing get_cdp_token()/get_tenant_endpoint() callers must dedup to a
+# single exchange rather than each firing their own (thundering herd), and the
+# token and its tenant endpoint must always come from the SAME exchange so a
+# reader never pairs one exchange's token with another's endpoint.
+# ---------------------------------------------------------------------------
+
+
+def _make_cold_exchanger(dataspace="default"):
+    """A DataCloudTokenExchanger over a JWT authenticator with no network wired.
+    Callers patch _fetch_new_token / _exchange_token to drive it deterministically."""
+    with patch("jwt.encode", return_value="mock_jwt"):
+        jwt_auth = JWTAuthenticator(
+            login_url="https://test.salesforce.com",
+            client_id="test_client_id",
+            username="test@example.com",
+            jwt_private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+    return DataCloudTokenExchanger(core_authenticator=jwt_auth, dataspace=dataspace)
+
+
+def test_concurrent_get_cdp_token_exchanges_exactly_once():
+    """N threads calling get_cdp_token() on a cold exchanger must trigger exactly
+    ONE token exchange. The CDP token is cacheable org-scoped state; today's
+    unlocked check-then-exchange admits every caller (thundering herd), so this
+    fails until get_cdp_token() single-flights the cold miss under a lock
+    (double-checked locking)."""
+    exchanger = _make_cold_exchanger()
+    parties = 8
+    gate = ConcurrencyGate()
+
+    def fake_fetch():
+        # Core token fetch is cheap and un-gated; only the exchange is counted.
+        return ("core_token", 7200, "https://myorg.my.salesforce.com")
+
+    def fake_exchange(instance_url, core_token):
+        gate.enter()  # counts every caller that reaches the exchange
+        return ("cdp_token", 3600, "https://tenant123.c360a.salesforce.com")
+
+    def worker(_i):
+        return exchanger.get_cdp_token()
+
+    with patch.object(
+        exchanger._core_authenticator, "_fetch_new_token", side_effect=fake_fetch
+    ), patch.object(exchanger, "_exchange_token", side_effect=fake_exchange):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    assert all(r == "cdp_token" for r in results)
+    assert gate.entered == 1  # deduplicated: only one thread exchanged
+    assert gate.max_concurrent == 1
+
+
+def test_concurrent_cdp_token_and_tenant_endpoint_derive_from_one_exchange():
+    """get_cdp_token() and get_tenant_endpoint() racing on a cold exchanger must
+    still perform exactly ONE exchange, and every returned (token, endpoint) must
+    come from that same exchange — never a torn pair drawn from two exchanges.
+
+    Each exchange embeds a distinct number in both its token and its endpoint, so
+    any cross-exchange pairing (or a second exchange) is caught."""
+    exchanger = _make_cold_exchanger()
+    parties = 16
+    gate = ConcurrencyGate()
+    counter = {"n": 0}
+    counter_lock = threading.Lock()
+
+    def fake_fetch():
+        return ("core_token", 7200, "https://myorg.my.salesforce.com")
+
+    def fake_exchange(instance_url, core_token):
+        with counter_lock:
+            counter["n"] += 1
+            n = counter["n"]
+        gate.enter()  # hold callers together so overlapping exchanges are exposed
+        return (f"cdp_token{n}", 3600, f"https://tenant{n}.c360a.salesforce.com")
+
+    def worker(i):
+        # Half the threads read the token, half read the endpoint — both must be
+        # served from the same single exchange.
+        if i % 2 == 0:
+            return ("token", exchanger.get_cdp_token())
+        return ("endpoint", exchanger.get_tenant_endpoint())
+
+    with patch.object(
+        exchanger._core_authenticator, "_fetch_new_token", side_effect=fake_fetch
+    ), patch.object(exchanger, "_exchange_token", side_effect=fake_exchange):
+        results, errors = gate.run(worker, parties)
+
+    assert errors == []
+    # Exactly one exchange happened despite the cold-miss stampede.
+    assert gate.entered == 1
+    assert gate.max_concurrent == 1
+    # The single exchange was #1, so every reader sees that exchange's values.
+    tokens = {v for kind, v in results if kind == "token"}
+    endpoints = {v for kind, v in results if kind == "endpoint"}
+    assert tokens == {"cdp_token1"}
+    assert endpoints == {"https://tenant1.c360a.salesforce.com"}


### PR DESCRIPTION
## What & why

Raises the v3 Python connector's DB-API 2.0 `threadsafety` from **1 → 2**, so
threads may share a single `Connection` (not just the module) — parity with the
legacy v1 driver. Cursors remain thread-confined, as PEP 249 level 2 allows.

GUS: **@W-24004700** — [Python Connector V3] Connection pooling — raise threadsafety to v1 parity (threadsafety=2)

## Approach

Built in TDD stages, each with a deterministic concurrency harness (barrier
release + a counting gate that discriminates a thundering herd from a
single-flight), so every production change had a real red→green:

1. **Concurrency harness + baseline guards** — `tests/_concurrency_helpers.py`
   (`run_concurrently` + `ConcurrencyGate`, with self-tests proving the gate
   discriminates racy vs. locked code) and characterization tests pinning the
   already-safe shared client / shared connection cursor-factory behavior.
2. **`oauth.py`** — lock-guarded publication of `instance_url`; new
   `get_oauth_token_and_instance_url()` returns `(access_token, instance_url)`
   from **one** fetch (HTTP outside the lock, only publication guarded); the
   cold-miss in `get_instance_url()` is single-flighted (double-checked locking).
   Core tokens are still never cached (matches JDBC).
3. **`token_exchanger.py`** — the three independently-mutable cache fields are
   replaced by one immutable `_CdpTokenCache` namedtuple published via a single
   atomic reference assignment, guarded by double-checked locking in
   `_ensure_cache()`. `get_cdp_token()`/`get_tenant_endpoint()` both derive from
   that one snapshot, so a reader can never pair a token with a mismatched
   endpoint, and N racing cold callers do **one** exchange. `invalidate_token()`
   now clears the whole snapshot atomically (fixes a prior stale-`tenant_endpoint`
   bug).
4. **Flip the flag** — `threadsafety = 2`, plus an end-to-end test (many threads
   share ONE `Connection`, each opens its own cursor and runs `execute → fetchall`
   with no cross-thread row bleed) and a topology test (two exchangers over one
   shared authenticator exchange concurrently). CHANGELOG updated under `2.0.0b2`.

## Testing

`uv run pytest -q` → **175 passed, 3 skipped**; `uv run ruff check` clean.

New concurrency tests fail against the pre-change code (thundering herd /
`threadsafety == 1`) and pass after each stage's fix.
